### PR TITLE
fix issue in partialLengthWriter buffering

### DIFF
--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -103,7 +103,7 @@ type partialLengthWriter struct {
 func (w *partialLengthWriter) Write(p []byte) (n int, err error) {
 	bufLen := w.buf.Len()
 	if bufLen > 512 {
-		for power := uint(14); power < 32; power-- {
+		for power := uint(30); power < 32; power-- {
 			l := 1 << power
 			if bufLen >= l {
 				w.lengthByte[0] = 224 + uint8(power)
@@ -268,8 +268,7 @@ func serializeStreamHeader(w io.WriteCloser, ptype packetType) (out io.WriteClos
 	if err != nil {
 		return
 	}
-	out = w
-	// out = &partialLengthWriter{w: w}
+	out = &partialLengthWriter{w: w}
 	return
 }
 

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -268,7 +268,8 @@ func serializeStreamHeader(w io.WriteCloser, ptype packetType) (out io.WriteClos
 	if err != nil {
 		return
 	}
-	out = &partialLengthWriter{w: w}
+	out = w
+	// out = &partialLengthWriter{w: w}
 	return
 }
 

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -103,7 +103,7 @@ type partialLengthWriter struct {
 func (w *partialLengthWriter) Write(p []byte) (n int, err error) {
 	bufLen := w.buf.Len()
 	if bufLen > 512 {
-		for power := uint(30); power < 32; power-- {
+		for power := uint(30); ; power-- {
 			l := 1 << power
 			if bufLen >= l {
 				w.lengthByte[0] = 224 + uint8(power)

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -8,11 +8,10 @@ import (
 	"crypto/cipher"
 	"crypto/sha1"
 	"crypto/subtle"
+	"golang.org/x/crypto/openpgp/errors"
 	"hash"
 	"io"
 	"strconv"
-
-	"golang.org/x/crypto/openpgp/errors"
 )
 
 // SymmetricallyEncrypted represents a symmetrically encrypted byte string. The

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -8,10 +8,11 @@ import (
 	"crypto/cipher"
 	"crypto/sha1"
 	"crypto/subtle"
-	"golang.org/x/crypto/openpgp/errors"
 	"hash"
 	"io"
 	"strconv"
+
+	"golang.org/x/crypto/openpgp/errors"
 )
 
 // SymmetricallyEncrypted represents a symmetrically encrypted byte string. The


### PR DESCRIPTION
Modify the partialLengthWriter to have a larger range of partialLength packets ( 2^30 instead of 2^14).
This fixes the issue where the partialLengthWriter buffer kept growing when writes were much larger than 2^14.