### PR TITLE
Remove redundant checks in Symmetrically Encrypted packet decryption

### DIFF
--- a/openpgp/packet/ocfb.go
+++ b/openpgp/packet/ocfb.go
@@ -85,8 +85,7 @@ type ocfbDecrypter struct {
 // NewOCFBDecrypter returns a cipher.Stream which decrypts data with OpenPGP's
 // cipher feedback mode using the given cipher.Block. Prefix must be the first
 // blockSize + 2 bytes of the ciphertext, where blockSize is the cipher.Block's
-// block size. If an incorrect key is detected then nil is returned. On
-// successful exit, blockSize+2 bytes of decrypted data are written into
+// block size. On successful exit, blockSize+2 bytes of decrypted data are written into
 // prefix. Resync determines if the "resynchronization step" from RFC 4880,
 // 13.9 step 7 is performed. Different parts of OpenPGP vary on this point.
 func NewOCFBDecrypter(block cipher.Block, prefix []byte, resync OCFBResyncOption) cipher.Stream {
@@ -111,11 +110,6 @@ func NewOCFBDecrypter(block cipher.Block, prefix []byte, resync OCFBResyncOption
 	block.Encrypt(x.fre, prefix[:blockSize])
 	prefixCopy[blockSize] ^= x.fre[0]
 	prefixCopy[blockSize+1] ^= x.fre[1]
-
-	if prefixCopy[blockSize-2] != prefixCopy[blockSize] ||
-		prefixCopy[blockSize-1] != prefixCopy[blockSize+1] {
-		return nil
-	}
 
 	if resync {
 		block.Encrypt(x.fre, prefix[2:])

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -8,10 +8,11 @@ import (
 	"crypto/cipher"
 	"crypto/sha1"
 	"crypto/subtle"
-	"github.com/ProtonMail/go-crypto/openpgp/errors"
 	"hash"
 	"io"
 	"strconv"
+
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
 )
 
 // SymmetricallyEncrypted represents a symmetrically encrypted byte string. The
@@ -42,8 +43,8 @@ func (se *SymmetricallyEncrypted) parse(r io.Reader) error {
 }
 
 // Decrypt returns a ReadCloser, from which the decrypted Contents of the
-// packet can be read. An incorrect key can, with high probability, be detected
-// immediately and this will result in a KeyIncorrect error being returned.
+// packet can be read. An incorrect key will only be detected after trying
+// to decrypt the entire data.
 func (se *SymmetricallyEncrypted) Decrypt(c CipherFunction, key []byte) (io.ReadCloser, error) {
 	keySize := c.KeySize()
 	if keySize == 0 {
@@ -70,9 +71,6 @@ func (se *SymmetricallyEncrypted) Decrypt(c CipherFunction, key []byte) (io.Read
 	}
 
 	s := NewOCFBDecrypter(c.new(key), se.prefix, ocfbResync)
-	if s == nil {
-		return nil, errors.ErrKeyIncorrect
-	}
 
 	plaintext := cipher.StreamReader{S: s, R: se.Contents}
 

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -195,14 +195,16 @@ func (ser *seMDCReader) Close() error {
 		}
 	}
 
-	if ser.trailer[0] != mdcPacketTagByte || ser.trailer[1] != sha1.Size {
-		return errors.SignatureError("MDC packet not found")
-	}
 	ser.h.Write(ser.trailer[:2])
 
 	final := ser.h.Sum(nil)
 	if subtle.ConstantTimeCompare(final, ser.trailer[2:]) != 1 {
 		return errors.SignatureError("hash mismatch")
+	}
+	// The hash already includes the MDC header, but we still check its value
+	// to confirm encryption correctness
+	if ser.trailer[0] != mdcPacketTagByte || ser.trailer[1] != sha1.Size {
+		return errors.SignatureError("MDC packet not found")
 	}
 	return nil
 }


### PR DESCRIPTION
Remove quick check that detects key correctness after partial data decryption, as the check is known to expose a decryption oracle: https://eprint.iacr.org/2005/033.pdf.