### PR TITLE
fix: Allow config to tell the detachSign function to ensure the `Signature.IssuerKeyId` == `signer.PrivateKey.KeyId`

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -74,12 +74,8 @@ type Config struct {
 	// this is not present or has a value of zero, it never expires."
 	// https://tools.ietf.org/html/rfc4880#section-5.2.3.10
 	SigLifetimeSecs uint32
-	// Tells the signing system to use the parent ID not subkey ID as the `Signature.IssuerKeyId`.
-	// Setting this to true will fix a bug in rpm < v4.13.0
-	// that prevents it from using subkey,KeyID to verify a signed package.
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1225133
-	// https://bugzilla.redhat.com/show_bug.cgi?id=227632
-	UseParentKeyOnly bool
+	// SigningKeyId specify signing key id to use, if not set defaults to best guess on subkeys.
+	SigningKeyId uint64
 }
 
 func (c *Config) Random() io.Reader {
@@ -160,3 +156,11 @@ func (c *Config) AEAD() *AEADConfig {
 	}
 	return c.AEADConfig
 }
+
+func (c *Config) SigningKey() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.SigningKeyId
+}
+

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -74,7 +74,9 @@ type Config struct {
 	// this is not present or has a value of zero, it never expires."
 	// https://tools.ietf.org/html/rfc4880#section-5.2.3.10
 	SigLifetimeSecs uint32
-	// SigningKeyId specify signing key id to use, if not set defaults to best guess on subkeys.
+	// SigningKeyId is used to specify the signing key to use (by Key ID).
+	// By default, the signing key is selected automatically, preferring
+	// signing subkeys if available.
 	SigningKeyId uint64
 }
 
@@ -163,4 +165,3 @@ func (c *Config) SigningKey() uint64 {
 	}
 	return c.SigningKeyId
 }
-

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -74,6 +74,12 @@ type Config struct {
 	// this is not present or has a value of zero, it never expires."
 	// https://tools.ietf.org/html/rfc4880#section-5.2.3.10
 	SigLifetimeSecs uint32
+	// Tells the signing system to use the parent ID not subkey ID as the `Signature.IssuerKeyId`.
+	// Setting this to true will fix a bug in rpm < v4.13.0
+	// that prevents it from using subkey,KeyID to verify a signed package.
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1225133
+	// https://bugzilla.redhat.com/show_bug.cgi?id=227632
+	UseParentKeyOnly bool
 }
 
 func (c *Config) Random() io.Reader {

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -67,6 +67,11 @@ func detachSign(w io.Writer, signer *Entity, message io.Reader, sigType packet.S
 	if signingKey.PrivateKey == nil {
 		return errors.InvalidArgumentError("signing key doesn't have a private key")
 	}
+	// Check if we should use the parent key, BUT only if the signer.PrivateKey.PrivateKey != nil which
+	// is caused by the parent being a s2k GNU dummy key (aka a exported subkey only)
+	if config != nil && config.UseParentKeyOnly && signer.PrivateKey.PrivateKey != nil {
+		signingKey.PrivateKey = signer.PrivateKey
+	}
 	if signingKey.PrivateKey.Encrypted {
 		return errors.InvalidArgumentError("signing key is encrypted")
 	}
@@ -533,7 +538,7 @@ func handleCompression(compressed io.WriteCloser, candidateCompression []uint8, 
 		return
 	}
 	finalAlgo := packet.CompressionNone
-	//if compression specified by config available we will use it
+	// if compression specified by config available we will use it
 	for _, c := range candidateCompression {
 		if uint8(confAlgo) == c {
 			finalAlgo = confAlgo


### PR DESCRIPTION
Allow config to tell the detachSign function to ensure the `Signature.IssuerKeyId` == `signer.PrivateKey.KeyId`

This fixes a bug in rpm < v4.13.0 that prevents it from using subkey.KeyID to verify a signed package
https://bugzilla.redhat.com/show_bug.cgi?id=1225133
https://bugzilla.redhat.com/show_bug.cgi?id=227632

This change is also required for https://github.com/goreleaser/nfpm/pull/315