### PR TITLE
rand: fix wasm global reference

### DIFF
--- a/internal/rand/rand_js.go
+++ b/internal/rand/rand_js.go
@@ -12,7 +12,7 @@ func init() {
 	Reader = &reader{}
 }
 
-var jsCrypto = js.Global.Get("crypto")
+var jsCrypto = js.Global().Get("crypto")
 
 // reader implements a pseudorandom generator
 // using JavaScript crypto.getRandomValues method.


### PR DESCRIPTION
Fixes this build error under GOOS=js GOARCH=wasm:

./rand_js.go:15:25: js.Global.Get undefined (type func() js.Value has no field or method Get)