### PR TITLE
Allow encrypting text messages to split writers

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -208,6 +208,15 @@ func EncryptSplit(keyWriter io.Writer, dataWriter io.Writer, to []*Entity, signe
 	return encrypt(keyWriter, dataWriter, to, signed, hints, packet.SigTypeBinary, config)
 }
 
+// EncryptTextSplit encrypts a message to a number of recipients and, optionally, signs
+// it. hints contains optional information, that is also encrypted, that aids
+// the recipients in processing the message. The resulting WriteCloser must
+// be closed after the contents of the file have been written.
+// If config is nil, sensible defaults will be used.
+func EncryptTextSplit(keyWriter io.Writer, dataWriter io.Writer, to []*Entity, signed *Entity, hints *FileHints, config *packet.Config) (plaintext io.WriteCloser, err error) {
+	return encrypt(keyWriter, dataWriter, to, signed, hints, packet.SigTypeText, config)
+}
+
 // writeAndSign writes the data as a payload package and, optionally, signs
 // it. hints contains optional information, that is also encrypted,
 // that aids the recipients in processing the message. The resulting


### PR DESCRIPTION
Adds a method to encrypt a text message, while providing two separate writers for the key and data packets.