### PR TITLE
Correctly serialize critical flag on signature subpackets

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -507,6 +507,9 @@ func serializeSubpackets(to []byte, subpackets []outputSubpacket, hashed bool) {
 		if subpacket.hashed == hashed {
 			n := serializeSubpacketLength(to, len(subpacket.contents)+1)
 			to[n] = byte(subpacket.subpacketType)
+			if subpacket.isCritical {
+				to[n] |= 0x80
+			}
 			to = to[1+n:]
 			n = copy(to, subpacket.contents)
 			to = to[n:]

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -76,4 +76,57 @@ func TestSignUserId(t *testing.T) {
 	}
 }
 
+func TestSignatureWithLifetime(t *testing.T) {
+	lifeTime := uint32(3600 * 24 * 30) // 30 days
+	sig := &Signature{
+		SigType:         SigTypeGenericCert,
+		PubKeyAlgo:      PubKeyAlgoRSA,
+		Hash:            0, // invalid hash function
+		SigLifetimeSecs: &lifeTime,
+	}
+
+	packet, err := Read(readerFromHex(rsaPkDataHex))
+	if err != nil {
+		t.Fatalf("failed to deserialize public key: %v", err)
+	}
+	pubKey := packet.(*PublicKey)
+
+	packet, err = Read(readerFromHex(privKeyRSAHex))
+	if err != nil {
+		t.Fatalf("failed to deserialize private key: %v", err)
+	}
+	privKey := packet.(*PrivateKey)
+
+	err = privKey.Decrypt([]byte("testing"))
+	if err != nil {
+		t.Fatalf("failed to decrypt private key: %v", err)
+	}
+
+	sig.Hash = crypto.SHA256
+	err = sig.SignUserId("", pubKey, privKey, nil)
+	if err != nil {
+		t.Errorf("failed to sign user id: %v", err)
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+	err = sig.Serialize(buf)
+	if err != nil {
+		t.Errorf("failed to serialize signature: %v", err)
+	}
+
+	packet, _ = Read(bytes.NewReader(buf.Bytes()))
+	sig = packet.(*Signature)
+	if sig.SigLifetimeSecs == nil || *sig.SigLifetimeSecs != lifeTime {
+		t.Errorf("signature lifetime is wrong: %d instead of %d", *sig.SigLifetimeSecs, lifeTime)
+	}
+
+	for _, subPacket := range sig.rawSubpackets {
+		if subPacket.subpacketType == signatureExpirationSubpacket {
+			if !subPacket.isCritical {
+				t.Errorf("signature expiration subpacket is not marked as critical")
+			}
+		}
+	}
+}
+
 const signatureDataHex = "c2c05c04000102000605024cb45112000a0910ab105c91af38fb158f8d07ff5596ea368c5efe015bed6e78348c0f033c931d5f2ce5db54ce7f2a7e4b4ad64db758d65a7a71773edeab7ba2a9e0908e6a94a1175edd86c1d843279f045b021a6971a72702fcbd650efc393c5474d5b59a15f96d2eaad4c4c426797e0dcca2803ef41c6ff234d403eec38f31d610c344c06f2401c262f0993b2e66cad8a81ebc4322c723e0d4ba09fe917e8777658307ad8329adacba821420741009dfe87f007759f0982275d028a392c6ed983a0d846f890b36148c7358bdb8a516007fac760261ecd06076813831a36d0459075d1befa245ae7f7fb103d92ca759e9498fe60ef8078a39a3beda510deea251ea9f0a7f0df6ef42060f20780360686f3e400e"

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -81,7 +81,7 @@ func TestSignatureWithLifetime(t *testing.T) {
 	sig := &Signature{
 		SigType:         SigTypeGenericCert,
 		PubKeyAlgo:      PubKeyAlgoRSA,
-		Hash:            0, // invalid hash function
+		Hash:            crypto.SHA256,
 		SigLifetimeSecs: &lifeTime,
 	}
 
@@ -102,7 +102,6 @@ func TestSignatureWithLifetime(t *testing.T) {
 		t.Fatalf("failed to decrypt private key: %v", err)
 	}
 
-	sig.Hash = crypto.SHA256
 	err = sig.SignUserId("", pubKey, privKey, nil)
 	if err != nil {
 		t.Errorf("failed to sign user id: %v", err)


### PR DESCRIPTION
The signature subpackets are correctly setting the isCritical field to true when an expiry date for a new signature is defined. This commit changes the serializeSubpackets function to take this field into account and set the critical bit accordingly.

I had previously sent this PR to golang/crypto but it has been closed because golang/x/crypto/openpgp has been frozen.

Critical subpackets need to have bit 7 set according to https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.3.1

The corresponding parser code in openpgp/packet/signature.go parseSignatureSubpacket is already doing the right thing.