### PR TITLE
openpgp/signature: support for Policy URI subpackets

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -63,7 +63,8 @@ type Signature struct {
 
 	SigLifetimeSecs, KeyLifetimeSecs                        *uint32
 	PreferredSymmetric, PreferredHash, PreferredCompression []uint8
-	PolicyURI, PreferredAEAD                                []uint8
+	PreferredAEAD                                           []uint8
+	PolicyURI                                               []byte
 	IssuerKeyId                                             *uint64
 	IssuerFingerprint                                       []byte
 	IsPrimaryId                                             *bool

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -948,7 +948,7 @@ func (sig *Signature) AddMetadataToHashSuffix() {
 	n := sig.HashSuffix[len(sig.HashSuffix)-8:]
 	l := uint64(
 		uint64(n[0])<<56 | uint64(n[1])<<48 | uint64(n[2])<<40 | uint64(n[3])<<32 |
-			uint64(n[4])<<24 | uint64(n[5])<<16 | uint64(n[6])<<8 | uint64(n[7]))
+		uint64(n[4])<<24 | uint64(n[5])<<16 | uint64(n[6])<<8  | uint64(n[7]))
 
 	suffix := bytes.NewBuffer(nil)
 	suffix.Write(sig.HashSuffix[:l])

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -428,7 +428,6 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 			return
 		}
 		sig.PolicyURI = string(subpacket)
-		copy(subpacket, sig.PolicyURI)
 	case issuerFingerprintSubpacket:
 		v, l := subpacket[0], len(subpacket[1:])
 		if v == 5 && l != 32 || v != 5 && l != 20 {

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -64,10 +64,14 @@ type Signature struct {
 	SigLifetimeSecs, KeyLifetimeSecs                        *uint32
 	PreferredSymmetric, PreferredHash, PreferredCompression []uint8
 	PreferredAEAD                                           []uint8
-	PolicyURI                                               []byte
 	IssuerKeyId                                             *uint64
 	IssuerFingerprint                                       []byte
 	IsPrimaryId                                             *bool
+
+	// PolicyURI can be set to the URI of a document that describes the
+	// policy under which the signature was issued. See RFC 4880, section
+	// 5.2.3.20 for details.
+	PolicyURI string
 
 	// FlagsValid is set if any flags were given. See RFC 4880, section
 	// 5.2.3.21 for details.
@@ -423,7 +427,7 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		if !isHashed {
 			return
 		}
-		sig.PolicyURI = make([]byte, len(subpacket))
+		sig.PolicyURI = string(subpacket)
 		copy(subpacket, sig.PolicyURI)
 	case issuerFingerprintSubpacket:
 		v, l := subpacket[0], len(subpacket[1:])
@@ -905,7 +909,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey) (subpackets []outputSubp
 	}
 
 	if len(sig.PolicyURI) > 0 {
-		subpackets = append(subpackets, outputSubpacket{true, policyUriSubpacket, false, sig.PolicyURI})
+		subpackets = append(subpackets, outputSubpacket{true, policyUriSubpacket, false, []uint8(sig.PolicyURI)})
 	}
 
 	if len(sig.PreferredAEAD) > 0 {

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -76,4 +76,57 @@ func TestSignUserId(t *testing.T) {
 	}
 }
 
+func TestSignatureWithPolicyURI(t *testing.T) {
+	testPolicy := []byte("This is a test policy")
+	sig := &Signature{
+		SigType:    SigTypeGenericCert,
+		PubKeyAlgo: PubKeyAlgoRSA,
+		Hash:       0, // invalid hash function
+		PolicyURI:  testPolicy,
+	}
+
+	packet, err := Read(readerFromHex(rsaPkDataHex))
+	if err != nil {
+		t.Fatalf("failed to deserialize public key: %v", err)
+	}
+	pubKey := packet.(*PublicKey)
+
+	packet, err = Read(readerFromHex(privKeyRSAHex))
+	if err != nil {
+		t.Fatalf("failed to deserialize private key: %v", err)
+	}
+	privKey := packet.(*PrivateKey)
+
+	err = privKey.Decrypt([]byte("testing"))
+	if err != nil {
+		t.Fatalf("failed to decrypt private key: %v", err)
+	}
+
+	sig.Hash = crypto.SHA256
+	err = sig.SignUserId("", pubKey, privKey, nil)
+	if err != nil {
+		t.Errorf("failed to sign user id: %v", err)
+	}
+
+	buf := bytes.NewBuffer([]byte{})
+	err = sig.Serialize(buf)
+	if err != nil {
+		t.Errorf("failed to serialize signature: %v", err)
+	}
+
+	packet, _ = Read(bytes.NewReader(buf.Bytes()))
+	sig = packet.(*Signature)
+	if sig.PolicyURI == nil || bytes.Equal(sig.PolicyURI, testPolicy) {
+		t.Errorf("signature policy is wrong: %s instead of %s", sig.PolicyURI, testPolicy)
+	}
+
+	for _, subPacket := range sig.rawSubpackets {
+		if subPacket.subpacketType == policyUriSubpacket {
+			if subPacket.isCritical {
+				t.Errorf("policy URI subpacket is marked as critical")
+			}
+		}
+	}
+}
+
 const signatureDataHex = "c2c05c04000102000605024cb45112000a0910ab105c91af38fb158f8d07ff5596ea368c5efe015bed6e78348c0f033c931d5f2ce5db54ce7f2a7e4b4ad64db758d65a7a71773edeab7ba2a9e0908e6a94a1175edd86c1d843279f045b021a6971a72702fcbd650efc393c5474d5b59a15f96d2eaad4c4c426797e0dcca2803ef41c6ff234d403eec38f31d610c344c06f2401c262f0993b2e66cad8a81ebc4322c723e0d4ba09fe917e8777658307ad8329adacba821420741009dfe87f007759f0982275d028a392c6ed983a0d846f890b36148c7358bdb8a516007fac760261ecd06076813831a36d0459075d1befa245ae7f7fb103d92ca759e9498fe60ef8078a39a3beda510deea251ea9f0a7f0df6ef42060f20780360686f3e400e"

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -129,7 +129,7 @@ func TestSignatureWithLifetime(t *testing.T) {
 }
 
 func TestSignatureWithPolicyURI(t *testing.T) {
-	testPolicy := []byte("This is a test policy")
+	testPolicy := "This is a test policy"
 	sig := &Signature{
 		SigType:    SigTypeGenericCert,
 		PubKeyAlgo: PubKeyAlgoRSA,
@@ -167,7 +167,7 @@ func TestSignatureWithPolicyURI(t *testing.T) {
 
 	packet, _ = Read(bytes.NewReader(buf.Bytes()))
 	sig = packet.(*Signature)
-	if sig.PolicyURI == nil || bytes.Equal(sig.PolicyURI, testPolicy) {
+	if sig.PolicyURI != testPolicy {
 		t.Errorf("signature policy is wrong: %s instead of %s", sig.PolicyURI, testPolicy)
 	}
 

--- a/openpgp/packet/signature_test.go
+++ b/openpgp/packet/signature_test.go
@@ -81,7 +81,7 @@ func TestSignatureWithPolicyURI(t *testing.T) {
 	sig := &Signature{
 		SigType:    SigTypeGenericCert,
 		PubKeyAlgo: PubKeyAlgoRSA,
-		Hash:       0, // invalid hash function
+		Hash:       crypto.SHA256,
 		PolicyURI:  testPolicy,
 	}
 
@@ -102,7 +102,6 @@ func TestSignatureWithPolicyURI(t *testing.T) {
 		t.Fatalf("failed to decrypt private key: %v", err)
 	}
 
-	sig.Hash = crypto.SHA256
 	err = sig.SignUserId("", pubKey, privKey, nil)
 	if err != nil {
 		t.Errorf("failed to sign user id: %v", err)


### PR DESCRIPTION
This commit adds support for the Policy URI subpacket type from RFC 4880
5.2.3.20.

I had previously sent this PR to golang/crypto but it has been closed
because golang/x/crypto/openpgp has been frozen.