### PR TITLE
Populate MessageDetails.SignatureError when unverified

### DIFF
--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -127,7 +127,7 @@ func checkSignedMessage(t *testing.T, signedHex, expected string) {
 		return
 	}
 
-	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.DecryptedWith.Entity != nil {
+	if !md.IsSigned || md.SignedByKeyId != 0xa34d7e18c20c31bb || md.SignedBy == nil || md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) != 0 || md.DecryptedWith.Entity != nil || md.SignatureError == nil {
 		t.Errorf("bad MessageDetails: %#v", md)
 	}
 
@@ -225,7 +225,7 @@ func TestSignedEncryptedMessage(t *testing.T) {
 			return
 		}
 
-		if !md.IsSigned || md.SignedByKeyId != test.signedByKeyId || md.SignedBy == nil || !md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) == 0 || md.EncryptedToKeyIds[0] != test.encryptedToKeyId {
+		if !md.IsSigned || md.SignedByKeyId != test.signedByKeyId || md.SignedBy == nil || !md.IsEncrypted || md.IsSymmetricallyEncrypted || len(md.EncryptedToKeyIds) == 0 || md.EncryptedToKeyIds[0] != test.encryptedToKeyId || md.SignatureError == nil {
 			t.Errorf("#%d: bad MessageDetails: %#v", i, md)
 		}
 


### PR DESCRIPTION
It's invalid for library users to look at MessageDetails.SignatureError
before the OpenPGP message is fully read. Populate it with an error
(cleared once the message is fully read).

This is technically a breaking change, but code looking at
SignatureError before the full message is read is broken anyways.

References: https://github.com/ProtonMail/go-crypto/issues/92