### PR TITLE
Don't generate AEAD messages by default

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -425,7 +425,7 @@ func encrypt(keyWriter io.Writer, dataWriter io.Writer, to []*Entity, signed *En
 	}
 
 	var payload io.WriteCloser
-	if aeadSupported {
+	if config.AEAD() != nil && aeadSupported {
 		payload, err = packet.SerializeAEADEncrypted(dataWriter, symKey, cipher, mode, config)
 		if err != nil {
 			return


### PR DESCRIPTION
Even if the public key supports AEAD, only generate AEAD messages if configured to do so, as AEAD is still experimental for now, so the meaning of the AEAD feature flag may still change.