### PR TITLE
Fix alternate simple form for userIDs

### DIFF
--- a/openpgp/packet/userid.go
+++ b/openpgp/packet/userid.go
@@ -156,5 +156,12 @@ func parseUserId(id string) (name, comment, email string) {
 	name = strings.TrimSpace(id[n.start:n.end])
 	comment = strings.TrimSpace(id[c.start:c.end])
 	email = strings.TrimSpace(id[e.start:e.end])
+
+	// RFC 2822 3.4: alternate simple form of a mailbox
+	if email == "" && strings.ContainsRune(name, '@') {
+		email = name
+		name = ""
+	}
+
 	return
 }

--- a/openpgp/packet/userid_test.go
+++ b/openpgp/packet/userid_test.go
@@ -24,6 +24,7 @@ var userIdTests = []struct {
 	{"  John Smith  < email > lksdfj", "John Smith", "", "email"},
 	{"(<foo", "", "<foo", ""},
 	{"René Descartes (العربي)", "René Descartes", "العربي", ""},
+	{"John@Smith", "", "", "John@Smith"},
 }
 
 func TestParseUserId(t *testing.T) {


### PR DESCRIPTION
When parsing an UserID like `test@example.com` this is to be considered an email address even without brackets according to RFC 2822 section 3.4