### PR TITLE
Switch ECDH to prefer byte format

### DIFF
--- a/openpgp/ecdh/ecdh_test.go
+++ b/openpgp/ecdh/ecdh_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/rand"
 	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
 	"io"
-	"math/big"
 	"testing"
 
 	"github.com/ProtonMail/go-crypto/openpgp/internal/algorithm"
@@ -80,7 +79,7 @@ func testValidation(t *testing.T, priv *PrivateKey) {
 		t.Fatalf("valid key marked as invalid: %s", err)
 	}
 
-	priv.X.Sub(priv.X, big.NewInt(1))
+	priv.D[5] ^= 1
 	if err := Validate(priv); err == nil {
 		t.Fatalf("failed to detect invalid key")
 	}
@@ -100,7 +99,7 @@ func testMarshalUnmarshal(t *testing.T, priv *PrivateKey) {
 		t.Fatalf("unable to unmarshal integer: %s", err)
 	}
 
-	if priv.X.Cmp(parsed.X) != 0 || (priv.Y != nil && priv.Y.Cmp(parsed.Y) != 0) || !bytes.Equal(priv.D, parsed.D) {
+	if !bytes.Equal(priv.Point, parsed.Point) || !bytes.Equal(priv.D, parsed.D) {
 		t.Fatal("failed to marshal/unmarshal correctly")
 	}
 }

--- a/openpgp/ecdh/ecdh_test.go
+++ b/openpgp/ecdh/ecdh_test.go
@@ -99,7 +99,17 @@ func testMarshalUnmarshal(t *testing.T, priv *PrivateKey) {
 		t.Fatalf("unable to unmarshal integer: %s", err)
 	}
 
-	if !bytes.Equal(priv.Point, parsed.Point) || !bytes.Equal(priv.D, parsed.D) {
+	expectedD := make([]byte, len(priv.D))
+	copy(expectedD, priv.D)
+
+	// Curve25519 expects keys to be saved clamped
+	if priv.curve.GetCurveName() == "curve25519" {
+		expectedD[0] &= 248
+		expectedD[31] &= 127
+		expectedD[31] |= 64
+	}
+
+	if !bytes.Equal(priv.Point, parsed.Point) || !bytes.Equal(expectedD, parsed.D) {
 		t.Fatal("failed to marshal/unmarshal correctly")
 	}
 }

--- a/openpgp/ecdsa/ecdsa.go
+++ b/openpgp/ecdsa/ecdsa.go
@@ -36,11 +36,11 @@ func (pk *PublicKey) GetCurve() ecc.ECDSACurve {
 }
 
 func (pk *PublicKey) MarshalPoint() []byte {
-	return pk.curve.MarshalPoint(pk.X, pk.Y)
+	return pk.curve.MarshalIntegerPoint(pk.X, pk.Y)
 }
 
 func (pk *PublicKey) UnmarshalPoint(p []byte) error {
-	pk.X, pk.Y = pk.curve.UnmarshalPoint(p)
+	pk.X, pk.Y = pk.curve.UnmarshalIntegerPoint(p)
 	if pk.X == nil {
 		return errors.New("ecdsa: failed to parse EC point")
 	}
@@ -76,5 +76,5 @@ func Verify(pub *PublicKey, hash []byte, r, s *big.Int) bool {
 }
 
 func Validate(priv *PrivateKey) error {
-	return priv.curve.Validate(priv.X, priv.Y, priv.D.Bytes())
+	return priv.curve.ValidateECDSA(priv.X, priv.Y, priv.D.Bytes())
 }

--- a/openpgp/eddsa/eddsa.go
+++ b/openpgp/eddsa/eddsa.go
@@ -76,5 +76,5 @@ func Verify(pub *PublicKey, message, r, s []byte) bool {
 }
 
 func Validate(priv *PrivateKey) error {
-	return priv.curve.Validate(priv.PublicKey.X, priv.D)
+	return priv.curve.ValidateEdDSA(priv.PublicKey.X, priv.D)
 }

--- a/openpgp/eddsa/eddsa.go
+++ b/openpgp/eddsa/eddsa.go
@@ -35,11 +35,11 @@ func (pk *PublicKey) GetCurve() ecc.EdDSACurve {
 }
 
 func (pk *PublicKey) MarshalPoint() []byte {
-	return pk.curve.MarshalPoint(pk.X)
+	return pk.curve.MarshalBytePoint(pk.X)
 }
 
 func (pk *PublicKey) UnmarshalPoint(x []byte) error {
-	pk.X = pk.curve.UnmarshalPoint(x)
+	pk.X = pk.curve.UnmarshalBytePoint(x)
 
 	if pk.X == nil {
 		return errors.New("eddsa: failed to parse EC point")

--- a/openpgp/internal/ecc/curve25519_test.go
+++ b/openpgp/internal/ecc/curve25519_test.go
@@ -15,22 +15,28 @@ import (
 // properly masked.
 func TestGenerateMaskedPrivateKeyX25519(t *testing.T) {
 	c := NewCurve25519()
-	priv, _, err := c.generateKeyPairBytes(rand.Reader)
+	_, secret, err := c.GenerateECDH(rand.Reader)
 	if err != nil  {
+		t.Fatal(err)
+	}
+
+	encoded := c.MarshalByteSecret(secret)
+	decoded := c.UnmarshalByteSecret(encoded)
+	if decoded == nil  {
 		t.Fatal(err)
 	}
 
 	// Check masking
 	// 3 lsb are 0
-	if priv[0]<<5 != 0 {
-		t.Fatalf("Priv. key is not masked (3 lsb should be unset): %X", priv)
+	if decoded[0]<<5 != 0 {
+		t.Fatalf("Priv. key is not masked (3 lsb should be unset): %X", decoded)
 	}
 	// MSB is 0
-	if priv[31]>>7 != 0 {
-		t.Fatalf("Priv. key is not masked (MSB should be unset): %X", priv)
+	if decoded[31]>>7 != 0 {
+		t.Fatalf("Priv. key is not masked (MSB should be unset): %X", decoded)
 	}
 	// Second-MSB is 1
-	if priv[31]>>6 != 1 {
-		t.Fatalf("Priv. key is not masked (second MSB should be set): %X", priv)
+	if decoded[31]>>6 != 1 {
+		t.Fatalf("Priv. key is not masked (second MSB should be set): %X", decoded)
 	}
 }

--- a/openpgp/internal/ecc/curves.go
+++ b/openpgp/internal/ecc/curves.go
@@ -32,7 +32,7 @@ type EdDSACurve interface {
 	GenerateEdDSA(rand io.Reader) (pub, priv []byte, err error)
 	Sign(publicKey, privateKey, message []byte) (r, s []byte, err error)
 	Verify(publicKey, message, r, s []byte) bool
-	Validate(publicKey, privateKey []byte) (err error)
+	ValidateEdDSA(publicKey, privateKey []byte) (err error)
 }
 type ECDHCurve interface {
 	Curve

--- a/openpgp/internal/ecc/curves.go
+++ b/openpgp/internal/ecc/curves.go
@@ -13,20 +13,20 @@ type Curve interface {
 
 type ECDSACurve interface {
 	Curve
-	MarshalPoint(x, y *big.Int) []byte
-	UnmarshalPoint([]byte) (x, y *big.Int)
+	MarshalIntegerPoint(x, y *big.Int) []byte
+	UnmarshalIntegerPoint([]byte) (x, y *big.Int)
 	MarshalIntegerSecret(d *big.Int) []byte
 	UnmarshalIntegerSecret(d []byte) *big.Int
 	GenerateECDSA(rand io.Reader) (x, y, secret *big.Int, err error)
 	Sign(rand io.Reader, x, y, d *big.Int, hash []byte) (r, s *big.Int, err error)
 	Verify(x, y *big.Int, hash []byte, r, s *big.Int) bool
-	Validate(x, y *big.Int, secret []byte) error
+	ValidateECDSA(x, y *big.Int, secret []byte) error
 }
 
 type EdDSACurve interface {
 	Curve
-	MarshalPoint(x []byte) []byte
-	UnmarshalPoint([]byte) (x []byte)
+	MarshalBytePoint(x []byte) []byte
+	UnmarshalBytePoint([]byte) (x []byte)
 	MarshalByteSecret(d []byte) []byte
 	UnmarshalByteSecret(d []byte) []byte
 	GenerateEdDSA(rand io.Reader) (pub, priv []byte, err error)
@@ -36,12 +36,12 @@ type EdDSACurve interface {
 }
 type ECDHCurve interface {
 	Curve
-	MarshalPoint(x, y *big.Int) []byte
-	UnmarshalPoint([]byte) (x, y *big.Int)
+	MarshalBytePoint([]byte) (encoded []byte)
+	UnmarshalBytePoint(encoded []byte) ([]byte)
 	MarshalByteSecret(d []byte) []byte
 	UnmarshalByteSecret(d []byte) []byte
-	GenerateECDH(rand io.Reader) (x, y *big.Int, secret []byte, err error)
-	Encaps(rand io.Reader, x, y *big.Int) (ephemeral, sharedSecret []byte, err error)
+	GenerateECDH(rand io.Reader) (point []byte, secret []byte, err error)
+	Encaps(rand io.Reader, point []byte) (ephemeral, sharedSecret []byte, err error)
 	Decaps(ephemeral, secret []byte) (sharedSecret []byte, err error)
-	Validate(x, y *big.Int, secret []byte) error
+	ValidateECDH(public []byte, secret []byte) error
 }

--- a/openpgp/internal/ecc/ed25519.go
+++ b/openpgp/internal/ecc/ed25519.go
@@ -89,7 +89,7 @@ func (c *ed25519) Verify(publicKey, message, r, s []byte) bool {
 	return ed25519lib.Verify(publicKey, message, signature)
 }
 
-func (c *ed25519) Validate(publicKey, privateKey []byte) (err error) {
+func (c *ed25519) ValidateEdDSA(publicKey, privateKey []byte) (err error) {
 	priv := getEd25519Sk(publicKey, privateKey)
 	expectedPriv := ed25519lib.NewKeyFromSeed(priv.Seed())
 	if subtle.ConstantTimeCompare(priv, expectedPriv) == 0 {

--- a/openpgp/internal/ecc/ed25519.go
+++ b/openpgp/internal/ecc/ed25519.go
@@ -24,12 +24,15 @@ func (c *ed25519) GetCurveName() string {
 	return "ed25519"
 }
 
+// MarshalBytePoint encodes the public point from native format, adding the prefix.
+// See https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 func (c *ed25519) MarshalBytePoint(x []byte) []byte {
 	return append([]byte{0x40}, x...)
 }
 
+// UnmarshalBytePoint decodes a point from prefixed format to native.
+// See https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 func (c *ed25519) UnmarshalBytePoint(point []byte) (x []byte) {
-	// Check size as per https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 	if len(point) != ed25519lib.PublicKeySize + 1 {
 		return nil
 	}
@@ -38,16 +41,20 @@ func (c *ed25519) UnmarshalBytePoint(point []byte) (x []byte) {
 	return point[1:]
 }
 
+// MarshalByteSecret encodes a scalar in native format.
+// See https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 func (c *ed25519) MarshalByteSecret(d []byte) []byte {
 	return d
 }
 
+// UnmarshalByteSecret decodes a scalar in native format and re-adds the stripped leading zeroes
+// See https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 func (c *ed25519) UnmarshalByteSecret(s []byte) (d []byte) {
 	if len(s) > ed25519lib.SeedSize {
 		return nil
 	}
 
-	// Handle stripped leading zeroes as per https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
+	// Handle stripped leading zeroes
 	d = make([]byte, ed25519lib.SeedSize)
 	copy(d[ed25519lib.SeedSize - len(s):], s)
 	return

--- a/openpgp/internal/ecc/ed25519.go
+++ b/openpgp/internal/ecc/ed25519.go
@@ -24,11 +24,11 @@ func (c *ed25519) GetCurveName() string {
 	return "ed25519"
 }
 
-func (c *ed25519) MarshalPoint(x []byte) []byte {
+func (c *ed25519) MarshalBytePoint(x []byte) []byte {
 	return append([]byte{0x40}, x...)
 }
 
-func (c *ed25519) UnmarshalPoint(point []byte) (x []byte) {
+func (c *ed25519) UnmarshalBytePoint(point []byte) (x []byte) {
 	// Check size as per https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh-06#section-5.5.5.5
 	if len(point) != ed25519lib.PublicKeySize + 1 {
 		return nil

--- a/openpgp/internal/ecc/ed25519_test.go
+++ b/openpgp/internal/ecc/ed25519_test.go
@@ -20,8 +20,8 @@ func TestEd25519MarshalUnmarshal(t *testing.T) {
 
 	x[0] = 0
 
-	encoded := c.MarshalPoint(x)
-	parsed := c.UnmarshalPoint(encoded)
+	encoded := c.MarshalBytePoint(x)
+	parsed := c.UnmarshalBytePoint(encoded)
 
 	if !bytes.Equal(x, parsed) {
 		t.Fatal("failed to marshal/unmarshal point correctly")

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -1387,8 +1387,8 @@ func TestKeyValidateOnDecrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Corrupt public X in subkey
-	X = ecdsaSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).X
-	ecdsaSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).X = new(big.Int).Add(X, big.NewInt(1))
+	ecdsaSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).Point[5] ^= 1
+
 	err = ecdsaSubkey.Decrypt(password)
 	if _, ok := err.(errors.KeyInvalidError); !ok {
 		t.Fatal("Failed to detect invalid ECDH key")
@@ -1417,20 +1417,19 @@ func TestKeyValidateOnDecrypt(t *testing.T) {
 		t.Fatal("Failed to detect invalid EdDSA key")
 	}
 	// ECDH ed25519
-	eddsaSubkey := eddsaEntity.Subkeys[0].PrivateKey
-	if err = eddsaSubkey.Encrypt(password); err != nil {
+	ecdhSubkey := eddsaEntity.Subkeys[0].PrivateKey
+	if err = ecdhSubkey.Encrypt(password); err != nil {
 		t.Fatal(err)
 	}
-	if err := eddsaSubkey.Decrypt(password); err != nil {
+	if err := ecdhSubkey.Decrypt(password); err != nil {
 		t.Fatal("Valid ECDH 25519 key was marked as invalid: ", err)
 	}
-	if err = eddsaSubkey.Encrypt(password); err != nil {
+	if err = ecdhSubkey.Encrypt(password); err != nil {
 		t.Fatal(err)
 	}
 	// Corrupt public X in subkey
-	X = eddsaSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).X
-	eddsaSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).X = new(big.Int).Add(X, big.NewInt(1))
-	err = eddsaSubkey.Decrypt(password)
+	ecdhSubkey.PublicKey.PublicKey.(*ecdh.PublicKey).Point[5] ^= 1
+	err = ecdhSubkey.Decrypt(password)
 	if _, ok := err.(errors.KeyInvalidError); !ok {
 		t.Fatal("Failed to detect invalid ECDH 25519 key")
 	}


### PR DESCRIPTION
Change internal ECDH interface to use bytes instead of big ints. This saves an encoding/decoding roundtrip for each X25519 and X448 operation, making NIST and Brainpool operations slightly less efficient by decoding big ints on each operation instead.