### PR TITLE
Uniform compatibility behaviour for buildkey retries

### DIFF
--- a/openpgp/ecdh/ecdh.go
+++ b/openpgp/ecdh/ecdh.go
@@ -121,10 +121,10 @@ func Decrypt(priv *PrivateKey, vsG, c, curveOID, fingerprint []byte) (msg []byte
 	var m []byte
 	zb, err := priv.PublicKey.curve.Decaps(vsG, priv.D)
 
-	for i := 0; i < priv.PublicKey.curve.GetBuildKeyAttempts(); i++ {
+	// Try buildKey three times to workaround an old bug, see comments in buildKey.
+	for i := 0; i < 3; i++ {
 		var z []byte
 		// RFC6637 §8: "Compute Z = KDF( S, Z_len, Param );"
-		// Try buildKey three times for compat, see comments in buildKey.
 		z, err = buildKey(&priv.PublicKey, zb, curveOID, fingerprint, i == 1, i == 2)
 		if err != nil {
 			return nil, err

--- a/openpgp/internal/ecc/curve25519.go
+++ b/openpgp/internal/ecc/curve25519.go
@@ -25,10 +25,6 @@ func (c *curve25519) GetCurveName() string {
 	return "curve25519"
 }
 
-func (c *curve25519) GetBuildKeyAttempts() int {
-	return 3
-}
-
 func (c *curve25519) MarshalPoint(x, y *big.Int) []byte {
 	return x.Bytes()
 }

--- a/openpgp/internal/ecc/curves.go
+++ b/openpgp/internal/ecc/curves.go
@@ -40,7 +40,6 @@ type ECDHCurve interface {
 	UnmarshalPoint([]byte) (x, y *big.Int)
 	MarshalByteSecret(d []byte) []byte
 	UnmarshalByteSecret(d []byte) []byte
-	GetBuildKeyAttempts() int
 	GenerateECDH(rand io.Reader) (x, y *big.Int, secret []byte, err error)
 	Encaps(rand io.Reader, x, y *big.Int) (ephemeral, sharedSecret []byte, err error)
 	Decaps(ephemeral, secret []byte) (sharedSecret []byte, err error)

--- a/openpgp/internal/ecc/generic.go
+++ b/openpgp/internal/ecc/generic.go
@@ -30,10 +30,6 @@ func (c *genericCurve) GetCurveType() CurveType {
 	return c.Type
 }
 
-func (c *genericCurve) GetBuildKeyAttempts() int {
-	return 1
-}
-
 func (c *genericCurve) MarshalPoint(x, y *big.Int) []byte {
 	return elliptic.Marshal(c.Curve, x, y)
 }


### PR DESCRIPTION
Make all curves retry the buildkey procedure three times with different attempts at stripped leading or trailing zeroes