### PR TITLE
Fix unencrypted PrivateKey checksum serialization

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -300,14 +300,8 @@ func (pk *PrivateKey) Serialize(w io.Writer) (err error) {
 				return err
 			}
 			l = buf.Len()
-			if pk.sha1Checksum {
-				h := sha1.New()
-				h.Write(buf.Bytes())
-				buf.Write(h.Sum(nil))
-			} else {
-				checksum := mod64kHash(buf.Bytes())
-				buf.Write([]byte{byte(checksum >> 8), byte(checksum)})
-			}
+			checksum := mod64kHash(buf.Bytes())
+			buf.Write([]byte{byte(checksum >> 8), byte(checksum)})
 			priv = buf.Bytes()
 		} else {
 			priv, l = pk.encryptedData, len(pk.encryptedData)

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -130,6 +130,26 @@ func TestNewEntity(t *testing.T) {
 	if !bytes.Equal(w.Bytes(), serialized) {
 		t.Errorf("results differed")
 	}
+
+	if err := e.PrivateKey.Encrypt([]byte("password")); err != nil {
+		t.Errorf("failed to encrypt private key: %s", err)
+	}
+
+	if err := e.PrivateKey.Decrypt([]byte("password")); err != nil {
+		t.Errorf("failed to decrypt private key: %s", err)
+	}
+
+	w = bytes.NewBuffer(nil)
+	if err := e.SerializePrivate(w, nil); err != nil {
+		t.Errorf("failed to serialize after encryption round: %s", err)
+		return
+	}
+
+	_, err = ReadKeyRing(w)
+	if err != nil {
+		t.Errorf("failed to reparse entity after encryption round: %s", err)
+		return
+	}
 }
 
 func TestEncryptWithCompression(t *testing.T) {


### PR DESCRIPTION
Avoid unencrypted private keys to be serialized with a sha1 checksum