### PR TITLE
Add support for compressed data packets with algorithm 0 (uncompressed)

### DIFF
--- a/openpgp/packet/compressed.go
+++ b/openpgp/packet/compressed.go
@@ -47,6 +47,8 @@ func (c *Compressed) parse(r io.Reader) error {
 	}
 
 	switch buf[0] {
+	case 0:
+		c.Body = r
 	case 1:
 		c.Body = flate.NewReader(r)
 	case 2:


### PR DESCRIPTION
Adds an uncompressed reader.

```
9.3.  Compression Algorithms

       ID           Algorithm
       --           ---------
       0          - Uncompressed
       1          - ZIP [RFC1951]
       2          - ZLIB [RFC1950]
       3          - BZip2 [BZ2]
       100 to 110 - Private/Experimental algorithm

   Implementations MUST implement uncompressed data.  Implementations
   SHOULD implement ZIP.  Implementations MAY implement any other
   algorithm.
```

The example payload we saw
```
gpg --verbose --list-packets myfile.pgp
gpg: armor header: Version: BCPG C# v
gpg: public key is AAAABBBBCCCCDDDD
gpg: encrypted with 4096-bit RSA key, ID AAAABBBBCCCCDDDD, created 2016-01
      mykey <mykey@example.com>"
gpg: CAST5 encrypted data
# off=0 ctb=85 tag=1 hlen=3 plen=524
:pubkey enc packet: version 3, algo 1, keyid AAAABBBBCCCCDDDD
	data: 0000...5555(replaced)
# off=527 ctb=d2 tag=18 hlen=2 plen=106 new-ctb
:encrypted data packet:
	length: 106
	mdc_method: 2
# off=540 ctb=a3 tag=8 hlen=1 plen=0 indeterminate
:compressed packet: algo=0
# off=542 ctb=cb tag=11 hlen=2 plen=69 new-ctb
:literal data packet:
	mode b (62), created 1660594213, name="_CONSOLE",
	raw data: 55 bytes
```

This payload errored out once it reached the packet with `:compressed packet: algo=0`. Upon adding the fix it parsed without errors.