### PR TITLE
Add support for creating Notation Data signature subpackets

### DIFF
--- a/openpgp/clearsign/clearsign.go
+++ b/openpgp/clearsign/clearsign.go
@@ -307,6 +307,7 @@ func (d *dashEscaper) Close() (err error) {
 		sig.Hash = d.hashType
 		sig.CreationTime = t
 		sig.IssuerKeyId = &k.KeyId
+		sig.Notations = d.config.Notations()
 
 		if err = sig.Sign(d.hashers[i], k, d.config); err != nil {
 			return

--- a/openpgp/integration_tests/end_to_end_test.go
+++ b/openpgp/integration_tests/end_to_end_test.go
@@ -308,7 +308,7 @@ func signVerifyTest(
 		}
 		if otherSigner.PrimaryKey.KeyId != skFrom[0].PrimaryKey.KeyId {
 			t.Errorf(
-				"wrong signer got:%x want:%x", otherSigner.PrimaryKey.KeyId, 0)
+				"wrong signer: got %x, expected %x", otherSigner.PrimaryKey.KeyId, 0)
 		}
 	}
 
@@ -333,7 +333,7 @@ func signVerifyTest(
 	}
 	if otherSigner.PrimaryKey.KeyId != skFrom[0].PrimaryKey.KeyId {
 		t.Errorf(
-			"wrong signer got:%x want:%x",
+			"wrong signer: got %x, expected %x",
 			skFrom[0].PrimaryKey.KeyId,
 			skFrom[0].PrimaryKey.KeyId,
 		)

--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -97,6 +97,7 @@ func (t *Entity) addUserId(name, comment, email string, config *packet.Config, c
 		FlagCertify:       true,
 		SEIPDv1:           true, // true by default, see 5.8 vs. 5.14
 		SEIPDv2:           config.AEAD() != nil,
+		Notations:         config.Notations(),
 	}
 
 	// Set the PreferredHash for the SelfSignature from the packet.Config.
@@ -185,7 +186,9 @@ func (e *Entity) AddSigningSubkey(config *packet.Config) error {
 				PubKeyAlgo:   sub.PublicKey.PubKeyAlgo,
 				Hash:         config.Hash(),
 				IssuerKeyId:  &e.PrimaryKey.KeyId,
+				Notations:    config.Notations(),
 			},
+			Notations:       config.Notations(),
 		},
 	}
 	if config != nil && config.V5Keys {
@@ -236,6 +239,7 @@ func (e *Entity) addEncryptionSubkey(config *packet.Config, creationTime time.Ti
 			FlagEncryptStorage:        true,
 			FlagEncryptCommunications: true,
 			IssuerKeyId:               &e.PrimaryKey.KeyId,
+			Notations:                 config.Notations(),
 		},
 	}
 	if config != nil && config.V5Keys {

--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -758,6 +758,7 @@ func (e *Entity) SignIdentity(identity string, signer *Entity, config *packet.Co
 		Hash:         config.Hash(),
 		CreationTime: config.Now(),
 		IssuerKeyId:  &certificationKey.PrivateKey.KeyId,
+		Notations:    config.Notations(),
 	}
 
 	if config.SigLifetime() != 0 {
@@ -792,6 +793,7 @@ func (e *Entity) RevokeKey(reason packet.ReasonForRevocation, reasonText string,
 		RevocationReason:     &reason,
 		RevocationReasonText: reasonText,
 		IssuerKeyId:          &e.PrimaryKey.KeyId,
+		Notations:            config.Notations(),
 	}
 
 	if err := revSig.RevokeKey(e.PrimaryKey, e.PrivateKey, config); err != nil {
@@ -818,6 +820,7 @@ func (e *Entity) RevokeSubkey(sk *Subkey, reason packet.ReasonForRevocation, rea
 		RevocationReason:     &reason,
 		RevocationReasonText: reasonText,
 		IssuerKeyId:          &e.PrimaryKey.KeyId,
+		Notations:            config.Notations(),
 	}
 
 	if err := revSig.RevokeSubkey(sk.PublicKey, e.PrivateKey, config); err != nil {

--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -994,8 +994,8 @@ func assertNotationPackets(t *testing.T, keys EntityList) {
 	}
 
 	notations := identity.Signatures[0].Notations
-	if numSigs, numExpected := len(notations), 2; numSigs != numExpected {
-		t.Fatalf("got %d Data Notation subpackets, expected %d", numSigs, numExpected)
+	if numNotations, numExpected := len(notations), 2; numNotations != numExpected {
+		t.Fatalf("got %d Notation Data subpackets, expected %d", numNotations, numExpected)
 	}
 
 	if notations[0].IsHumanReadable != true {
@@ -1003,11 +1003,11 @@ func assertNotationPackets(t *testing.T, keys EntityList) {
 	}
 
 	if notations[0].Name != "text@example.com" {
-		t.Fatalf("got %s, expected test@example.com", notations[0].Name)
+		t.Fatalf("got %s, expected text@example.com", notations[0].Name)
 	}
 
 	if string(notations[0].Value) != "test" {
-		t.Fatalf("got %s, expected 2", string(notations[0].Value))
+		t.Fatalf("got %s, expected \"test\"", string(notations[0].Value))
 	}
 
 	if notations[1].IsHumanReadable != false {
@@ -1015,11 +1015,11 @@ func assertNotationPackets(t *testing.T, keys EntityList) {
 	}
 
 	if notations[1].Name != "binary@example.com" {
-		t.Fatalf("got %s, expected test@example.com", notations[1].Name)
+		t.Fatalf("got %s, expected binary@example.com", notations[1].Name)
 	}
 
 	if !bytes.Equal(notations[1].Value, []byte{0, 1, 2, 3}) {
-		t.Fatalf("got %s, expected 3", string(notations[1].Value))
+		t.Fatalf("got %s, expected {0, 1, 2, 3}", string(notations[1].Value))
 	}
 }
 

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -98,6 +98,8 @@ type Config struct {
 	// the notation names that are allowed to be present in critical Notation Data
 	// signature subpackets.
 	KnownNotations map[string]bool
+	// SignatureNotations is a list of Notations to be added to any signatures.
+	SignatureNotations []*Notation
 }
 
 func (c *Config) Random() io.Reader {
@@ -212,4 +214,11 @@ func (c *Config) KnownNotation(notationName string) bool {
 		return false
 	}
 	return c.KnownNotations[notationName]
+}
+
+func (c *Config) Notations() []*Notation {
+	if c == nil {
+		return nil
+	}
+	return c.SignatureNotations
 }

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -353,7 +353,7 @@ func testDetachedSignature(t *testing.T, kring KeyRing, signature io.Reader, sig
 		return
 	}
 	if signer.PrimaryKey.KeyId != expectedSignerKeyId {
-		t.Errorf("%s: wrong signer got:%x want:%x", tag, signer.PrimaryKey.KeyId, expectedSignerKeyId)
+		t.Errorf("%s: wrong signer: got %x, expected %x", tag, signer.PrimaryKey.KeyId, expectedSignerKeyId)
 	}
 }
 

--- a/openpgp/read_write_test_data.go
+++ b/openpgp/read_write_test_data.go
@@ -1,8 +1,8 @@
 package openpgp
 
-const testKey1KeyId = 0xA34D7E18C20C31BB
-const testKey3KeyId = 0x338934250CCC0360
-const testKeyP256KeyId = 0xd44a2c495918513e
+const testKey1KeyId uint64 = 0xA34D7E18C20C31BB
+const testKey3KeyId uint64 = 0x338934250CCC0360
+const testKeyP256KeyId uint64 = 0xd44a2c495918513e
 
 const signedInput = "Signed message\nline 2\nline 3\n"
 const signedTextInput = "Signed message\r\nline 2\r\nline 3\r\n"

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -82,6 +82,7 @@ func detachSign(w io.Writer, signer *Entity, message io.Reader, sigType packet.S
 	sigLifetimeSecs := config.SigLifetime()
 	sig.SigLifetimeSecs = &sigLifetimeSecs
 	sig.IssuerKeyId = &signingKey.PrivateKey.KeyId
+	sig.Notations = config.Notations()
 
 	h, wrappedHash, err := hashForSignature(sig.Hash, sig.SigType)
 	if err != nil {
@@ -520,6 +521,7 @@ func (s signatureWriter) Close() error {
 		CreationTime: s.config.Now(),
 		IssuerKeyId:  &s.signer.KeyId,
 		Metadata:     s.metadata,
+		Notations:    s.config.Notations(),
 	}
 
 	if err := sig.Sign(s.h, s.signer, s.config); err != nil {


### PR DESCRIPTION
Add `config.SignatureNotations []*Notation`, which will be added to any signatures created during the operation that the config is passed to.

Built on top of #146, should be merged after that one. For the main change, see c19bb963d9ad4506bff2e4d7119d60a2a0ccf7de.