### PR TITLE
Unify signature creation

### DIFF
--- a/openpgp/clearsign/clearsign.go
+++ b/openpgp/clearsign/clearsign.go
@@ -307,7 +307,10 @@ func (d *dashEscaper) Close() (err error) {
 		sig.Hash = d.hashType
 		sig.CreationTime = t
 		sig.IssuerKeyId = &k.KeyId
+		sig.IssuerFingerprint = k.Fingerprint
 		sig.Notations = d.config.Notations()
+		sigLifetimeSecs := d.config.SigLifetime()
+		sig.SigLifetimeSecs = &sigLifetimeSecs
 
 		if err = sig.Sign(d.hashers[i], k, d.config); err != nil {
 			return

--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -157,6 +157,10 @@ func (e *Entity) AddSigningSubkey(config *packet.Config) error {
 		return err
 	}
 	sub := packet.NewSignerPrivateKey(creationTime, subPrivRaw)
+	sub.IsSubkey = true
+	if config != nil && config.V5Keys {
+		sub.UpgradeToV5()
+	}
 
 	subkey := Subkey{
 		PublicKey:  &sub.PublicKey,
@@ -170,18 +174,13 @@ func (e *Entity) AddSigningSubkey(config *packet.Config) error {
 	subkey.Sig.EmbeddedSignature = createSignaturePacket(subkey.PublicKey, packet.SigTypePrimaryKeyBinding, config)
 	subkey.Sig.EmbeddedSignature.CreationTime = creationTime
 
-	if config != nil && config.V5Keys {
-		subkey.PublicKey.UpgradeToV5()
-	}
-
 	err = subkey.Sig.EmbeddedSignature.CrossSignKey(subkey.PublicKey, e.PrimaryKey, subkey.PrivateKey, config)
 	if err != nil {
 		return err
 	}
 
-	subkey.PublicKey.IsSubkey = true
-	subkey.PrivateKey.IsSubkey = true
-	if err = subkey.Sig.SignKey(subkey.PublicKey, e.PrivateKey, config); err != nil {
+	err = subkey.Sig.SignKey(subkey.PublicKey, e.PrivateKey, config)
+	if err != nil {
 		return err
 	}
 
@@ -203,6 +202,10 @@ func (e *Entity) addEncryptionSubkey(config *packet.Config, creationTime time.Ti
 		return err
 	}
 	sub := packet.NewDecrypterPrivateKey(creationTime, subPrivRaw)
+	sub.IsSubkey = true
+	if config != nil && config.V5Keys {
+		sub.UpgradeToV5()
+	}
 
 	subkey := Subkey{
 		PublicKey:  &sub.PublicKey,
@@ -215,13 +218,8 @@ func (e *Entity) addEncryptionSubkey(config *packet.Config, creationTime time.Ti
 	subkey.Sig.FlagEncryptStorage = true
 	subkey.Sig.FlagEncryptCommunications = true
 
-	if config != nil && config.V5Keys {
-		subkey.PublicKey.UpgradeToV5()
-	}
-
-	subkey.PublicKey.IsSubkey = true
-	subkey.PrivateKey.IsSubkey = true
-	if err = subkey.Sig.SignKey(subkey.PublicKey, e.PrivateKey, config); err != nil {
+	err = subkey.Sig.SignKey(subkey.PublicKey, e.PrivateKey, config)
+	if err != nil {
 		return err
 	}
 

--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -751,19 +751,7 @@ func (e *Entity) SignIdentity(identity string, signer *Entity, config *packet.Co
 		return errors.InvalidArgumentError("given identity string not found in Entity")
 	}
 
-	sig := &packet.Signature{
-		Version:      certificationKey.PrivateKey.Version,
-		SigType:      packet.SigTypeGenericCert,
-		PubKeyAlgo:   certificationKey.PrivateKey.PubKeyAlgo,
-		Hash:         config.Hash(),
-		CreationTime: config.Now(),
-		IssuerKeyId:  &certificationKey.PrivateKey.KeyId,
-		Notations:    config.Notations(),
-	}
-
-	if config.SigLifetime() != 0 {
-		sig.SigLifetimeSecs = &config.SigLifetimeSecs
-	}
+	sig := createSignaturePacket(certificationKey.PublicKey, packet.SigTypeGenericCert, config)
 
 	signingUserID := config.SigningUserId()
 	if signingUserID != "" {
@@ -784,17 +772,9 @@ func (e *Entity) SignIdentity(identity string, signer *Entity, config *packet.Co
 // specified reason code and text (RFC4880 section-5.2.3.23).
 // If config is nil, sensible defaults will be used.
 func (e *Entity) RevokeKey(reason packet.ReasonForRevocation, reasonText string, config *packet.Config) error {
-	revSig := &packet.Signature{
-		Version:              e.PrimaryKey.Version,
-		CreationTime:         config.Now(),
-		SigType:              packet.SigTypeKeyRevocation,
-		PubKeyAlgo:           e.PrimaryKey.PubKeyAlgo,
-		Hash:                 config.Hash(),
-		RevocationReason:     &reason,
-		RevocationReasonText: reasonText,
-		IssuerKeyId:          &e.PrimaryKey.KeyId,
-		Notations:            config.Notations(),
-	}
+	revSig := createSignaturePacket(e.PrimaryKey, packet.SigTypeKeyRevocation, config)
+	revSig.RevocationReason = &reason
+	revSig.RevocationReasonText = reasonText
 
 	if err := revSig.RevokeKey(e.PrimaryKey, e.PrivateKey, config); err != nil {
 		return err
@@ -811,17 +791,9 @@ func (e *Entity) RevokeSubkey(sk *Subkey, reason packet.ReasonForRevocation, rea
 		return errors.InvalidArgumentError("given subkey is not associated with this key")
 	}
 
-	revSig := &packet.Signature{
-		Version:              e.PrimaryKey.Version,
-		CreationTime:         config.Now(),
-		SigType:              packet.SigTypeSubkeyRevocation,
-		PubKeyAlgo:           e.PrimaryKey.PubKeyAlgo,
-		Hash:                 config.Hash(),
-		RevocationReason:     &reason,
-		RevocationReasonText: reasonText,
-		IssuerKeyId:          &e.PrimaryKey.KeyId,
-		Notations:            config.Notations(),
-	}
+	revSig := createSignaturePacket(e.PrimaryKey, packet.SigTypeSubkeyRevocation, config)
+	revSig.RevocationReason = &reason
+	revSig.RevocationReasonText = reasonText
 
 	if err := revSig.RevokeSubkey(sk.PublicKey, e.PrivateKey, config); err != nil {
 		return err


### PR DESCRIPTION
Make signature packet creation more uniform:

- Consistently add an Issuer Fingerprint to all signatures.
- Consistently add a Signature Expiration Time when `config.SigLifetimeSecs` is set.
- When generating a signing subkey, use the version of the subkey to determine the version of the cross-signature, rather than the version of the primary key.
- Similarly, fix the Issuer Key ID of signing subkey cross-signatures to refer to the subkey instead of the primary key.
