### PR TITLE
Expose helpers for hash functions

### DIFF
--- a/openpgp/hash.go
+++ b/openpgp/hash.go
@@ -1,0 +1,24 @@
+package openpgp
+
+import (
+	"crypto"
+
+	"github.com/ProtonMail/go-crypto/openpgp/internal/algorithm"
+)
+
+// HashIdToHash returns a crypto.Hash which corresponds to the given OpenPGP
+// hash id.
+func HashIdToHash(id byte) (h crypto.Hash, ok bool) {
+	return algorithm.HashIdToHash(id)
+}
+
+// HashIdToString returns the name of the hash function corresponding to the
+// given OpenPGP hash id.
+func HashIdToString(id byte) (name string, ok bool) {
+	return algorithm.HashIdToString(id)
+}
+
+// HashToHashId returns an OpenPGP hash id which corresponds the given Hash.
+func HashToHashId(h crypto.Hash) (id byte, ok bool) {
+	return algorithm.HashToHashId(h)
+}


### PR DESCRIPTION
The library has a few helpers to deal with hash functions and their openpgp ids that were hidden in an internal package. This adds public wrappers to expose them.