### PR TITLE
Add support for Argon2 S2K

### DIFF
--- a/openpgp/integration_tests/utils_test.go
+++ b/openpgp/integration_tests/utils_test.go
@@ -268,15 +268,15 @@ func randConfig() *packet.Config {
 		v5 = true
 	}
 
-	var s2kConf *s2k.S2KConfig
+	var s2kConf *s2k.Config
 	if mathrand.Int()%2 == 0 {
-		s2kConf = &s2k.S2KConfig{
-			S2KMode:  s2k.IterSaltedS2K,
+		s2kConf = &s2k.Config{
+			S2KMode:  s2k.IteratedSaltedS2K,
 			Hash:     hash,
 			S2KCount: 1024 + mathrand.Intn(65010689),
 		}
 	} else {
-		s2kConf = &s2k.S2KConfig{
+		s2kConf = &s2k.Config{
 			S2KMode: s2k.Argon2S2K,
 		}
 	}

--- a/openpgp/integration_tests/utils_test.go
+++ b/openpgp/integration_tests/utils_test.go
@@ -146,7 +146,7 @@ func randFileHints() *openpgp.FileHints {
 	return &openpgp.FileHints{
 		IsBinary: mathrand.Intn(2) == 0,
 		FileName: string(fileName),
-		ModTime:  time.Now(),
+		ModTime: time.Now(),
 	}
 }
 

--- a/openpgp/integration_tests/utils_test.go
+++ b/openpgp/integration_tests/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 // This function produces random test vectors: generates keys according to the
@@ -145,7 +146,7 @@ func randFileHints() *openpgp.FileHints {
 	return &openpgp.FileHints{
 		IsBinary: mathrand.Intn(2) == 0,
 		FileName: string(fileName),
-		ModTime: time.Now(),
+		ModTime:  time.Now(),
 	}
 }
 
@@ -267,6 +268,19 @@ func randConfig() *packet.Config {
 		v5 = true
 	}
 
+	var s2kConf *s2k.S2KConfig
+	if mathrand.Int()%2 == 0 {
+		s2kConf = &s2k.S2KConfig{
+			S2KMode:  s2k.IterSaltedS2K,
+			Hash:     hash,
+			S2KCount: 1024 + mathrand.Intn(65010689),
+		}
+	} else {
+		s2kConf = &s2k.S2KConfig{
+			S2KMode: s2k.Argon2S2K,
+		}
+	}
+
 	return &packet.Config{
 		V5Keys:                 v5,
 		Rand:                   rand.Reader,
@@ -274,7 +288,7 @@ func randConfig() *packet.Config {
 		DefaultCipher:          ciph,
 		DefaultCompressionAlgo: compAlgo,
 		CompressionConfig:      compConf,
-		S2KCount:               1024 + mathrand.Intn(65010689),
+		S2KConfig:              s2kConf,
 		RSABits:                rsaBits,
 		Algorithm:              pkAlgo,
 		AEADConfig:             &aeadConf,

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	// S2K (String to Key) config, used for key derivation in the context of secret key encryption
 	// and password-encrypted data.
 	// If nil, the default configuration is used
-	S2KConfig *s2k.S2KConfig
+	S2KConfig *s2k.Config
 	// RSABits is the number of bits in new RSA keys made with NewEntity.
 	// If zero, then 2048 bit keys are created.
 	RSABits int
@@ -169,7 +169,7 @@ func (c *Config) CurveName() Curve {
 	return c.Curve
 }
 
-func (c *Config) S2K() *s2k.S2KConfig {
+func (c *Config) S2K() *s2k.Config {
 	if c == nil {
 		return nil
 	}

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	// If nil, the default configuration is used
 	S2KConfig *s2k.Config
 	// Iteration count for Iterated S2K (String to Key). 
-	// Only relevant if sk2.Mode is set to s2k.IteratedSaltedS2K.
+	// Only used if sk2.Mode is nil.
 	// This value is duplicated here from s2k.Config for backwards compatibility.
 	// It determines the strength of the passphrase stretching when
 	// the said passphrase is hashed to produce a key. S2KCount

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	// be encoded exactly. When set, it is strongly encrouraged to
 	// use a value that is at least 65536. See RFC 4880 Section
 	// 3.7.1.3.
+	//
+	// Deprecated: SK2Count should be configured in S2KConfig instead.
 	S2KCount int
 	// RSABits is the number of bits in new RSA keys made with NewEntity.
 	// If zero, then 2048 bit keys are created.
@@ -182,6 +184,7 @@ func (c *Config) CurveName() Curve {
 	return c.Curve
 }
 
+// Deprecated: The hash iterations should now be queried via the S2K() method.
 func (c *Config) PasswordHashIterations() int {
 	if c == nil || c.S2KCount == 0 {
 		return 0

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -49,7 +49,7 @@ type PrivateKey struct {
 	s2kParams *s2k.Params
 }
 
-// S2KType s2k packet type
+//S2KType s2k packet type
 type S2KType uint8
 
 const (

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -430,7 +430,7 @@ func (pk *PrivateKey) Decrypt(passphrase []byte) error {
 	return nil
 }
 
-func (pk *PrivateKey) encryptHelper(passphrase []byte, cf CipherFunction, s2kConfig *s2k.S2KConfig) error {
+func (pk *PrivateKey) encrypt(passphrase []byte, cf CipherFunction, s2kConfig *s2k.S2KConfig) error {
 	priv := bytes.NewBuffer(nil)
 	err := pk.serializePrivateKey(priv)
 	if err != nil {
@@ -484,7 +484,7 @@ func (pk *PrivateKey) encryptHelper(passphrase []byte, cf CipherFunction, s2kCon
 
 // encryptWithConfig encrypts an unencrypted private key using a passphrase and with the config.
 func (pk *PrivateKey) encryptWithConfig(passphrase []byte, c *Config) error {
-	return pk.encryptHelper(passphrase, c.Cipher(), c.S2K())
+	return pk.encrypt(passphrase, c.Cipher(), c.S2K())
 }
 
 // Encrypt encrypts an unencrypted private key using a passphrase.
@@ -494,7 +494,7 @@ func (pk *PrivateKey) Encrypt(passphrase []byte) error {
 		S2KCount: 65536,
 		Hash:     crypto.SHA256,
 	}
-	return pk.encryptHelper(passphrase, CipherAES256, s2kConfig)
+	return pk.encrypt(passphrase, CipherAES256, s2kConfig)
 }
 
 func (pk *PrivateKey) serializePrivateKey(w io.Writer) (err error) {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -430,7 +430,7 @@ func (pk *PrivateKey) Decrypt(passphrase []byte) error {
 	return nil
 }
 
-func (pk *PrivateKey) encrypt(passphrase []byte, cf CipherFunction, s2kConfig *s2k.Config) error {
+func (pk *PrivateKey) encrypt(passphrase []byte, cipher CipherFunction, s2kConfig *s2k.Config) error {
 	priv := bytes.NewBuffer(nil)
 	err := pk.serializePrivateKey(priv)
 	if err != nil {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -430,14 +430,14 @@ func (pk *PrivateKey) Decrypt(passphrase []byte) error {
 	return nil
 }
 
-func (pk *PrivateKey) encrypt(passphrase []byte, cipher CipherFunction, s2kConfig *s2k.Config) error {
+func (pk *PrivateKey) encrypt(passphrase []byte, blockCipher CipherFunction, s2kConfig *s2k.Config) error {
 	priv := bytes.NewBuffer(nil)
 	err := pk.serializePrivateKey(priv)
 	if err != nil {
 		return err
 	}
 
-	pk.cipher = cf
+	pk.cipher = blockCipher
 
 	pk.s2kParams, err = s2k.Generate(rand.Reader, s2kConfig)
 	if err != nil {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -430,7 +430,7 @@ func (pk *PrivateKey) Decrypt(passphrase []byte) error {
 	return nil
 }
 
-func (pk *PrivateKey) encrypt(passphrase []byte, cf CipherFunction, s2kConfig *s2k.S2KConfig) error {
+func (pk *PrivateKey) encrypt(passphrase []byte, cf CipherFunction, s2kConfig *s2k.Config) error {
 	priv := bytes.NewBuffer(nil)
 	err := pk.serializePrivateKey(priv)
 	if err != nil {
@@ -489,8 +489,8 @@ func (pk *PrivateKey) encryptWithConfig(passphrase []byte, c *Config) error {
 
 // Encrypt encrypts an unencrypted private key using a passphrase.
 func (pk *PrivateKey) Encrypt(passphrase []byte) error {
-	s2kConfig := &s2k.S2KConfig{
-		S2KMode:  s2k.IterSaltedS2K,
+	s2kConfig := &s2k.Config{
+		S2KMode:  s2k.IteratedSaltedS2K,
 		S2KCount: 65536,
 		Hash:     crypto.SHA256,
 	}

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -140,7 +140,7 @@ func TestExternalPrivateKeyEncryptDecryptRandomizeSlow(t *testing.T) {
 
 func TestExternalPrivateKeyEncryptDecryptArgon2(t *testing.T) {
 	config := &Config{
-		S2KConfig: &s2k.S2KConfig{S2KMode: s2k.Argon2S2K},
+		S2KConfig: &s2k.Config{S2KMode: s2k.Argon2S2K},
 	}
 	for i, test := range privateKeyTests {
 		packet, err := Read(readerFromHex(test.privateKeyHex))

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/eddsa"
 	"github.com/ProtonMail/go-crypto/openpgp/elgamal"
 	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 const maxMessageLength = 1 << 10
@@ -101,6 +102,71 @@ func TestExternalPrivateKeyEncryptDecryptRandomizeSlow(t *testing.T) {
 		randomPassword := make([]byte, mathrand.Intn(30))
 		rand.Read(randomPassword)
 		err = privKey.Encrypt(randomPassword)
+		if err != nil {
+			t.Errorf("#%d: failed to encrypt: %s", i, err)
+			continue
+		}
+
+		// Try to decrypt with incorrect password
+		incorrect := make([]byte, 1+mathrand.Intn(30))
+		for rand.Read(incorrect); bytes.Equal(incorrect, randomPassword); {
+			rand.Read(incorrect)
+		}
+		err = privKey.Decrypt(incorrect)
+		if err == nil {
+			t.Errorf("#%d: decrypted with incorrect password\nPassword is:%vDecrypted with:%v", i, randomPassword, incorrect)
+			continue
+		}
+
+		// Try to decrypt with old password
+		err = privKey.Decrypt([]byte("testing"))
+		if err == nil {
+			t.Errorf("#%d: decrypted with old password", i)
+			continue
+		}
+
+		// Decrypt with correct password
+		err = privKey.Decrypt(randomPassword)
+		if err != nil {
+			t.Errorf("#%d: failed to decrypt: %s", i, err)
+			continue
+		}
+
+		if !privKey.CreationTime.Equal(test.creationTime) || privKey.Encrypted {
+			t.Errorf("#%d: bad result, got: %#v", i, privKey)
+		}
+	}
+}
+
+func TestExternalPrivateKeyEncryptDecryptArgon2(t *testing.T) {
+	config := &Config{
+		S2KConfig: &s2k.S2KConfig{S2KMode: s2k.Argon2S2K},
+	}
+	for i, test := range privateKeyTests {
+		packet, err := Read(readerFromHex(test.privateKeyHex))
+		if err != nil {
+			t.Errorf("#%d: failed to parse: %s", i, err)
+			continue
+		}
+
+		privKey := packet.(*PrivateKey)
+
+		if !privKey.Encrypted {
+			t.Errorf("#%d: private key isn't encrypted", i)
+			continue
+		}
+
+		// Decrypt with the correct password
+		err = privKey.Decrypt([]byte("testing"))
+		if err != nil {
+			t.Errorf("#%d: failed to decrypt: %s", i, err)
+			continue
+		}
+
+		// Encrypt with another (possibly empty) password
+		randomPassword := make([]byte, mathrand.Intn(30))
+		rand.Read(randomPassword)
+		err = privKey.encryptWithConfig(randomPassword, config)
 		if err != nil {
 			t.Errorf("#%d: failed to encrypt: %s", i, err)
 			continue

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -198,7 +198,7 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 	}
 	cipherFunc := config.Cipher()
 	// cipherFunc must be AES
-	if !cipherFunc.IsSupported() ||  cipherFunc < CipherAES128 || cipherFunc > CipherAES256 {
+	if !cipherFunc.IsSupported() || cipherFunc < CipherAES128 || cipherFunc > CipherAES256 {
 		return errors.UnsupportedError("unsupported cipher: " + strconv.Itoa(int(cipherFunc)))
 	}
 
@@ -207,7 +207,7 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 	keyEncryptingKey := make([]byte, keySize)
 	// s2k.Serialize salts and stretches the passphrase, and writes the
 	// resulting key to keyEncryptingKey and the s2k descriptor to s2kBuf.
-	err = s2k.Serialize(s2kBuf, keyEncryptingKey, config.Random(), passphrase, &s2k.Config{Hash: config.Hash(), S2KCount: config.PasswordHashIterations()})
+	err = s2k.Serialize(s2kBuf, keyEncryptingKey, config.Random(), passphrase, config.S2K())
 	if err != nil {
 		return
 	}
@@ -232,7 +232,7 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 
 	if version == 5 {
 		// Scalar octet count
-		buf = append(buf, byte(3 + len(s2kBytes) + config.AEAD().Mode().IvLength()))
+		buf = append(buf, byte(3+len(s2kBytes)+config.AEAD().Mode().IvLength()))
 	}
 
 	// Cipher function

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -198,7 +198,7 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 	}
 	cipherFunc := config.Cipher()
 	// cipherFunc must be AES
-	if !cipherFunc.IsSupported() || cipherFunc < CipherAES128 || cipherFunc > CipherAES256 {
+	if !cipherFunc.IsSupported() ||  cipherFunc < CipherAES128 || cipherFunc > CipherAES256 {
 		return errors.UnsupportedError("unsupported cipher: " + strconv.Itoa(int(cipherFunc)))
 	}
 
@@ -232,7 +232,7 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 
 	if version == 5 {
 		// Scalar octet count
-		buf = append(buf, byte(3+len(s2kBytes)+config.AEAD().Mode().IvLength()))
+		buf = append(buf, byte(3 + len(s2kBytes) + config.AEAD().Mode().IvLength()))
 	}
 
 	// Cipher function

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -80,8 +80,8 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 		"GCM": AEADModeGCM,
 	}
 
-	modesS2K := map[string]s2k.S2KType{
-		"Iterated": s2k.IterSaltedS2K,
+	modesS2K := map[string]s2k.Mode{
+		"Iterated": s2k.IteratedSaltedS2K,
 		"Argon2":   s2k.Argon2S2K,
 	}
 
@@ -97,7 +97,7 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 							config := &Config{
 								DefaultCipher: cipher,
 								AEADConfig:    &AEADConfig{DefaultMode: mode},
-								S2KConfig:     &s2k.S2KConfig{S2KMode: s2ktype},
+								S2KConfig:     &s2k.Config{S2KMode: s2ktype},
 							}
 
 							key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
@@ -132,8 +132,8 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 		"AES256": CipherAES256,
 	}
 
-	testS2K := map[string]s2k.S2KType{
-		"Iterated": s2k.IterSaltedS2K,
+	testS2K := map[string]s2k.Mode{
+		"Iterated": s2k.IteratedSaltedS2K,
 		"Argon2":   s2k.Argon2S2K,
 	}
 
@@ -148,7 +148,7 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 					}
 					config := &Config{
 						DefaultCipher: cipher,
-						S2KConfig: &s2k.S2KConfig{
+						S2KConfig: &s2k.Config{
 							S2KMode: s2ktype,
 						},
 					}

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -12,6 +12,8 @@ import (
 	"io/ioutil"
 	mathrand "math/rand"
 	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp/s2k"
 )
 
 const maxPassLen = 64
@@ -66,46 +68,56 @@ func TestDecryptSymmetricKeyAndEncryptedDataPacket(t *testing.T) {
 }
 
 func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
-	ciphers := map[string] CipherFunction {
+	ciphers := map[string]CipherFunction{
 		"AES128": CipherAES128,
 		"AES192": CipherAES192,
 		"AES256": CipherAES256,
 	}
 
-	modes := map[string] AEADMode {
+	modes := map[string]AEADMode{
 		"EAX": AEADModeEAX,
 		"OCB": AEADModeOCB,
 		"GCM": AEADModeGCM,
+	}
+
+	modesS2K := map[string]s2k.S2KType{
+		"Iterated": s2k.IterSaltedS2K,
+		"Argon2":   s2k.Argon2S2K,
 	}
 
 	for cipherName, cipher := range ciphers {
 		t.Run(cipherName, func(t *testing.T) {
 			for modeName, mode := range modes {
 				t.Run(modeName, func(t *testing.T) {
-					var buf bytes.Buffer
-					passphrase := randomKey(mathrand.Intn(maxPassLen))
+					for s2kName, s2ktype := range modesS2K {
+						t.Run(s2kName, func(t *testing.T) {
+							var buf bytes.Buffer
+							passphrase := randomKey(mathrand.Intn(maxPassLen))
 
-					config := &Config{
-						DefaultCipher: cipher,
-						AEADConfig:    &AEADConfig{DefaultMode: mode},
-					}
+							config := &Config{
+								DefaultCipher: cipher,
+								AEADConfig:    &AEADConfig{DefaultMode: mode},
+								S2KConfig:     &s2k.S2KConfig{S2KMode: s2ktype},
+							}
 
-					key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
-					p, err := Read(&buf)
-					if err != nil {
-						t.Errorf("failed to reparse %s", err)
-					}
-					ske, ok := p.(*SymmetricKeyEncrypted)
-					if !ok {
-						t.Errorf("parsed a different packet type: %#v", p)
-					}
+							key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
+							p, err := Read(&buf)
+							if err != nil {
+								t.Errorf("failed to reparse %s", err)
+							}
+							ske, ok := p.(*SymmetricKeyEncrypted)
+							if !ok {
+								t.Errorf("parsed a different packet type: %#v", p)
+							}
 
-					parsedKey, _, err := ske.Decrypt(passphrase)
-					if err != nil {
-						t.Errorf("failed to decrypt reparsed SKE: %s", err)
-					}
-					if !bytes.Equal(key, parsedKey) {
-						t.Errorf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
+							parsedKey, _, err := ske.Decrypt(passphrase)
+							if err != nil {
+								t.Errorf("failed to decrypt reparsed SKE: %s", err)
+							}
+							if !bytes.Equal(key, parsedKey) {
+								t.Errorf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
+							}
+						})
 					}
 				})
 			}
@@ -114,51 +126,63 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 }
 
 func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
-	tests := map[string] CipherFunction {
+	tests := map[string]CipherFunction{
 		"AES128": CipherAES128,
 		"AES192": CipherAES192,
 		"AES256": CipherAES256,
 	}
 
+	testS2K := map[string]s2k.S2KType{
+		"Iterated": s2k.IterSaltedS2K,
+		"Argon2":   s2k.Argon2S2K,
+	}
+
 	for cipherName, cipher := range tests {
 		t.Run(cipherName, func(t *testing.T) {
-			var buf bytes.Buffer
-			passphrase := make([]byte, mathrand.Intn(maxPassLen))
-			if _, err := rand.Read(passphrase); err != nil {
-				panic(err)
-			}
-			config := &Config{
-				DefaultCipher: cipher,
-			}
+			for s2kName, s2ktype := range testS2K {
+				t.Run(s2kName, func(t *testing.T) {
+					var buf bytes.Buffer
+					passphrase := make([]byte, mathrand.Intn(maxPassLen))
+					if _, err := rand.Read(passphrase); err != nil {
+						panic(err)
+					}
+					config := &Config{
+						DefaultCipher: cipher,
+						S2KConfig: &s2k.S2KConfig{
+							S2KMode: s2ktype,
+						},
+					}
 
-			key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
-			if err != nil {
-				t.Fatalf("failed to serialize: %s", err)
-			}
+					key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
+					if err != nil {
+						t.Fatalf("failed to serialize: %s", err)
+					}
 
-			p, err := Read(&buf)
-			if err != nil {
-				t.Fatalf("failed to reparse: %s", err)
-			}
+					p, err := Read(&buf)
+					if err != nil {
+						t.Fatalf("failed to reparse: %s", err)
+					}
 
-			ske, ok := p.(*SymmetricKeyEncrypted)
-			if !ok {
-				t.Fatalf("parsed a different packet type: %#v", p)
-			}
+					ske, ok := p.(*SymmetricKeyEncrypted)
+					if !ok {
+						t.Fatalf("parsed a different packet type: %#v", p)
+					}
 
-			if ske.CipherFunc != config.DefaultCipher {
-				t.Fatalf("SKE cipher function is %d (expected %d)", ske.CipherFunc, config.DefaultCipher)
-			}
-			parsedKey, parsedCipherFunc, err := ske.Decrypt(passphrase)
-			if err != nil {
-				t.Fatalf("failed to decrypt reparsed SKE: %s", err)
-			}
-			if !bytes.Equal(key, parsedKey) {
-				t.Fatalf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
-			}
-			if parsedCipherFunc != cipher {
-				t.Fatalf("cipher function doesn't match after Decrypt: %d (original) vs %d (parsed)",
-					cipher, parsedCipherFunc)
+					if ske.CipherFunc != config.DefaultCipher {
+						t.Fatalf("SKE cipher function is %d (expected %d)", ske.CipherFunc, config.DefaultCipher)
+					}
+					parsedKey, parsedCipherFunc, err := ske.Decrypt(passphrase)
+					if err != nil {
+						t.Fatalf("failed to decrypt reparsed SKE: %s", err)
+					}
+					if !bytes.Equal(key, parsedKey) {
+						t.Fatalf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
+					}
+					if parsedCipherFunc != cipher {
+						t.Fatalf("cipher function doesn't match after Decrypt: %d (original) vs %d (parsed)",
+							cipher, parsedCipherFunc)
+					}
+				})
 			}
 		})
 	}

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -18,64 +18,6 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-type Mode uint8
-
-// Defines the default S2KMode constants
-//
-//	0 (simple), 1(salted), 3(iterated), 4(argon2)
-const (
-	SimpleS2K     Mode 	  = 0
-	SaltedS2K             = 1
-	IteratedSaltedS2K     = 3
-	Argon2S2K             = 4
-	GnuS2K                = 101
-)
-
-const Argon2SaltSize int = 16
-
-// Config collects configuration parameters for s2k key-stretching
-// transformations. A nil *Config is valid and results in all default
-// values.
-type Config struct {
-	// S2K (String to Key) mode, used for key derivation in the context of secret key encryption
-	// and password-encrypted data. Either s2k.Argon2S2K or s2k.IteratedSaltedS2K has to be selected
-	// weaker options are not allowed.
-	// Note: Argon2 is the strongest option but not all OpenPGP implementations are compatible with it
-	//(pending standardisation).
-	// 0 (simple), 1(salted), 3(iterated), 4(argon2)
-	// 2(reserved) 100-110(private/experimental).
-	S2KMode Mode
-	// Only relevant if S2KMode is not set to s2k.Argon2S2K.
-	// Hash is the default hash function to be used. If
-	// nil, SHA256 is used.
-	Hash crypto.Hash
-	// Argon2 parameters for S2K (String to Key).
-	// Only relevant if S2KMode is set to s2k.Argon2S2K.
-	// If nil, default parameters are used.
-	// For more details on the choice of parameters, see https://tools.ietf.org/html/rfc9106#section-4.
-	ArgonConfig *ArgonConfig
-	// Only relevant if S2KMode is set to s2k.IteratedSaltedS2K.
-	// Iteration count for Iterated S2K (String to Key). It
-	// determines the strength of the passphrase stretching when
-	// the said passphrase is hashed to produce a key. S2KCount
-	// should be between 65536 and 65011712, inclusive. If Config
-	// is nil or S2KCount is 0, the value 16777216 used. Not all
-	// values in the above range can be represented. S2KCount will
-	// be rounded up to the next representable value if it cannot
-	// be encoded exactly. When set, it is strongly encrouraged to
-	// use a value that is at least 65536. See RFC 4880 Section
-	// 3.7.1.3.
-	S2KCount int
-}
-
-// ArgonConfig stores the Argon2 parameters
-// A nil *ArgonConfig is valid and results in all default
-type ArgonConfig struct {
-	NumberOfPasses      uint8
-	DegreeOfParallelism uint8
-	MemoryExponent      uint8
-}
-
 // Params contains all the parameters of the s2k packet
 type Params struct {
 	// mode is the mode of s2k function.
@@ -99,67 +41,6 @@ type Params struct {
 	// i.e., 2 ** memoryExp kibibytes
 	// See RFC the crypto refresh Section 3.7.1.4.
 	memoryExp byte
-}
-
-func (c *Config) Mode() Mode {
-	if c == nil {
-		return IteratedSaltedS2K
-	}
-	return c.S2KMode
-}
-
-func (c *Config) hash() crypto.Hash {
-	if c == nil || uint(c.Hash) == 0 {
-		return crypto.SHA256
-	}
-
-	return c.Hash
-}
-
-func (c *Config) Argon2() *ArgonConfig {
-	if c == nil || c.ArgonConfig == nil {
-		return nil
-	}
-	return c.ArgonConfig
-}
-
-// EncodedCount get encoded count
-func (c *Config) EncodedCount() uint8 {
-	if c == nil || c.S2KCount == 0 {
-		return 224 // The common case. Corresponding to 16777216
-	}
-
-	i := c.S2KCount
-
-	switch {
-	case i < 65536:
-		i = 65536
-	case i > 65011712:
-		i = 65011712
-	}
-
-	return encodeCount(i)
-}
-
-func (c *ArgonConfig) Passes() uint8 {
-	if c == nil || c.NumberOfPasses == 0 {
-		return 3
-	}
-	return c.NumberOfPasses
-}
-
-func (c *ArgonConfig) Parallelism() uint8 {
-	if c == nil || c.NumberOfPasses == 0 {
-		return 4
-	}
-	return c.DegreeOfParallelism
-}
-
-func (c *ArgonConfig) Exponent() uint8 {
-	if c == nil || c.MemoryExponent == 0 {
-		return 16 // 64 MiB of RAM
-	}
-	return c.MemoryExponent
 }
 
 // encodeCount converts an iterative "count" in the range 1024 to

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -58,8 +58,8 @@ type Config struct {
 	// Iteration count for Iterated S2K (String to Key). It
 	// determines the strength of the passphrase stretching when
 	// the said passphrase is hashed to produce a key. S2KCount
-	// should be between 1024 and 65011712, inclusive. If Config
-	// is nil or S2KCount is 0, the value 65536 used. Not all
+	// should be between 65536 and 65011712, inclusive. If Config
+	// is nil or S2KCount is 0, the value 16777216 used. Not all
 	// values in the above range can be represented. S2KCount will
 	// be rounded up to the next representable value if it cannot
 	// be encoded exactly. When set, it is strongly encrouraged to
@@ -90,14 +90,14 @@ type Params struct {
 	// be performed in s2k mode 3. See RFC 4880 Section 3.7.1.3.
 	countByte byte
 	// passes is a parameter in Argon2 to determine the number of iterations
-	// See RFC 4880 Section 3.7.1.4.
+	// See RFC the crypto refresh Section 3.7.1.4.
 	passes byte
 	// parallelism is a parameter in Argon2 to determine the degree of paralellism
-	// See RFC 4880 Section 3.7.1.4.
+	// See RFC the crypto refresh Section 3.7.1.4.
 	parallelism byte
 	// memoryExp is a parameter in Argon2 to determine the memory usage
-	// i.e., 2 pow memoryExp kibibytes
-	// See RFC 4880 Section 3.7.1.4.
+	// i.e., 2 ** memoryExp kibibytes
+	// See RFC the crypto refresh Section 3.7.1.4.
 	memoryExp byte
 }
 
@@ -256,7 +256,7 @@ func memoryExpToKibibytes(memoryExp uint8) uint32 {
 }
 
 // Argon2 writes to out the key derived from the password (in) with the Argon2
-// function (RFC 4880, section 3.7.1.4)
+// function (the crypto refresh, section 3.7.1.4)
 func Argon2(out []byte, in []byte, salt []byte, passes uint8, paralellism uint8, memoryExp uint8) {
 	key := argon2.IDKey(in, salt, uint32(passes), memoryExpToKibibytes(memoryExp), paralellism, uint32(len(out)))
 	copy(out[:], key)

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -18,6 +18,21 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
+type Mode uint8
+
+// Defines the default S2KMode constants
+//
+//	0 (simple), 1(salted), 3(iterated), 4(argon2)
+const (
+	SimpleS2K         Mode = 0
+	SaltedS2K              = 1
+	IteratedSaltedS2K      = 3
+	Argon2S2K              = 4
+	GnuS2K                 = 101
+)
+
+const Argon2SaltSize int = 16
+
 // Params contains all the parameters of the s2k packet
 type Params struct {
 	// mode is the mode of s2k function.

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -261,12 +261,9 @@ func Argon2Derive(out []byte, in []byte, salt []byte, passes uint8, paralellism 
 // It will enforce salted + hashed s2k method
 func Generate(rand io.Reader, c *S2KConfig) (*Params, error) {
 	var params *Params
-	// if the mode is Argon2, we require Argon2 parameters
 	if c != nil && c.S2KMode == Argon2S2K {
-		var argonConfig = c.ArgonConf
-		if argonConfig == nil {
-			argonConfig = DefaultArgonConfig()
-		}
+		// handle Argon2 case
+		argonConfig := c.ArgonConfig()
 		params = &Params{
 			mode:        Argon2S2K,
 			salt:        make([]byte, Argon2S2KDefaultNonceSize),
@@ -275,6 +272,7 @@ func Generate(rand io.Reader, c *S2KConfig) (*Params, error) {
 			memoryExp:   argonConfig.MemoryExponent,
 		}
 	} else {
+		// handle IterSaltedS2K case
 		hashId, ok := algorithm.HashToHashId(c.hash())
 		if !ok {
 			return nil, errors.UnsupportedError("no such hash")

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -106,7 +106,7 @@ func encodeMemory(memory uint32, parallelism uint8) uint8 {
 
 // decodeMemory computes the decoded memory in kibibytes as 2**memoryExponent
 func decodeMemory(memoryExponent uint8) uint32 {
-	return (uint32(1) << memoryExponent)
+	return uint32(1) << memoryExponent
 }
 
 // Simple writes to out the result of computing the Simple S2K function (RFC

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -123,13 +123,6 @@ func (c *Config) Argon2() *ArgonConfig {
 	return c.ArgonConfig
 }
 
-func (c *Config) Count() int {
-	if c == nil || c.S2KCount == 0 {
-		return 65536
-	}
-	return c.S2KCount
-}
-
 // EncodedCount get encoded count
 func (c *Config) EncodedCount() uint8 {
 	if c == nil || c.S2KCount == 0 {

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -258,7 +258,7 @@ func Argon2Derive(out []byte, in []byte, salt []byte, passes uint8, paralellism 
 }
 
 // Generate generates valid parameters from given configuration.
-// It will enforce salted + hashed s2k method
+// It will enforce the Iterated and Salted or Argon2 S2K method.
 func Generate(rand io.Reader, c *S2KConfig) (*Params, error) {
 	var params *Params
 	if c != nil && c.S2KMode == Argon2S2K {

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -44,7 +44,7 @@ type ArgonConfig struct {
 	DegreeOfParallelism uint8
 	// The memory parameter for Argon2 specifies desired memory usage in kibibytes. 
 	// For example memory=64*1024 sets the memory cost to ~64 MB.
-	Memory      		uint32 
+	Memory      	    uint32 
 }
 
 func (c *Config) Mode() Mode {

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -106,16 +106,16 @@ func (c *ArgonConfig) EncodedMemory() uint8 {
 		return 16 // 64 MiB of RAM
 	}
 
-	temp := c.Memory
+	memory := c.Memory
 	lowerBound := uint32(c.Parallelism())*8
 	upperBound := uint32(2147483648)
 
 	switch {
-	case temp < lowerBound:
-		temp = lowerBound
-	case temp > upperBound:
-		temp = upperBound
+	case memory < lowerBound:
+		memory = lowerBound
+	case memory > upperBound:
+		memory = upperBound
 	}
 
-	return encodeMemory(temp, c.Parallelism())
+	return encodeMemory(memory, c.Parallelism())
 }

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -2,21 +2,6 @@ package s2k
 
 import "crypto"
 
-type Mode uint8
-
-// Defines the default S2KMode constants
-//
-//	0 (simple), 1(salted), 3(iterated), 4(argon2)
-const (
-	SimpleS2K         Mode = 0
-	SaltedS2K              = 1
-	IteratedSaltedS2K      = 3
-	Argon2S2K              = 4
-	GnuS2K                 = 101
-)
-
-const Argon2SaltSize int = 16
-
 // Config collects configuration parameters for s2k key-stretching
 // transformations. A nil *Config is valid and results in all default
 // values.

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -1,0 +1,122 @@
+package s2k
+
+import "crypto"
+
+type Mode uint8
+
+// Defines the default S2KMode constants
+//
+//	0 (simple), 1(salted), 3(iterated), 4(argon2)
+const (
+	SimpleS2K         Mode = 0
+	SaltedS2K              = 1
+	IteratedSaltedS2K      = 3
+	Argon2S2K              = 4
+	GnuS2K                 = 101
+)
+
+const Argon2SaltSize int = 16
+
+// Config collects configuration parameters for s2k key-stretching
+// transformations. A nil *Config is valid and results in all default
+// values.
+type Config struct {
+	// S2K (String to Key) mode, used for key derivation in the context of secret key encryption
+	// and password-encrypted data. Either s2k.Argon2S2K or s2k.IteratedSaltedS2K has to be selected
+	// weaker options are not allowed.
+	// Note: Argon2 is the strongest option but not all OpenPGP implementations are compatible with it
+	//(pending standardisation).
+	// 0 (simple), 1(salted), 3(iterated), 4(argon2)
+	// 2(reserved) 100-110(private/experimental).
+	S2KMode Mode
+	// Only relevant if S2KMode is not set to s2k.Argon2S2K.
+	// Hash is the default hash function to be used. If
+	// nil, SHA256 is used.
+	Hash crypto.Hash
+	// Argon2 parameters for S2K (String to Key).
+	// Only relevant if S2KMode is set to s2k.Argon2S2K.
+	// If nil, default parameters are used.
+	// For more details on the choice of parameters, see https://tools.ietf.org/html/rfc9106#section-4.
+	ArgonConfig *ArgonConfig
+	// Only relevant if S2KMode is set to s2k.IteratedSaltedS2K.
+	// Iteration count for Iterated S2K (String to Key). It
+	// determines the strength of the passphrase stretching when
+	// the said passphrase is hashed to produce a key. S2KCount
+	// should be between 65536 and 65011712, inclusive. If Config
+	// is nil or S2KCount is 0, the value 16777216 used. Not all
+	// values in the above range can be represented. S2KCount will
+	// be rounded up to the next representable value if it cannot
+	// be encoded exactly. When set, it is strongly encrouraged to
+	// use a value that is at least 65536. See RFC 4880 Section
+	// 3.7.1.3.
+	S2KCount int
+}
+
+// ArgonConfig stores the Argon2 parameters
+// A nil *ArgonConfig is valid and results in all default
+type ArgonConfig struct {
+	NumberOfPasses      uint8
+	DegreeOfParallelism uint8
+	MemoryExponent      uint8
+}
+
+func (c *Config) Mode() Mode {
+	if c == nil {
+		return IteratedSaltedS2K
+	}
+	return c.S2KMode
+}
+
+func (c *Config) hash() crypto.Hash {
+	if c == nil || uint(c.Hash) == 0 {
+		return crypto.SHA256
+	}
+
+	return c.Hash
+}
+
+func (c *Config) Argon2() *ArgonConfig {
+	if c == nil || c.ArgonConfig == nil {
+		return nil
+	}
+	return c.ArgonConfig
+}
+
+// EncodedCount get encoded count
+func (c *Config) EncodedCount() uint8 {
+	if c == nil || c.S2KCount == 0 {
+		return 224 // The common case. Corresponding to 16777216
+	}
+
+	i := c.S2KCount
+
+	switch {
+	case i < 65536:
+		i = 65536
+	case i > 65011712:
+		i = 65011712
+	}
+
+	return encodeCount(i)
+}
+
+func (c *ArgonConfig) Passes() uint8 {
+	if c == nil || c.NumberOfPasses == 0 {
+		return 3
+	}
+	return c.NumberOfPasses
+}
+
+func (c *ArgonConfig) Parallelism() uint8 {
+	if c == nil || c.NumberOfPasses == 0 {
+		return 4
+	}
+	return c.DegreeOfParallelism
+}
+
+func (c *ArgonConfig) Exponent() uint8 {
+	if c == nil || c.MemoryExponent == 0 {
+		return 16 // 64 MiB of RAM
+	}
+	return c.MemoryExponent
+}

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -22,7 +22,7 @@ type Config struct {
 	// Only relevant if S2KMode is set to s2k.Argon2S2K.
 	// If nil, default parameters are used.
 	// For more details on the choice of parameters, see https://tools.ietf.org/html/rfc9106#section-4.
-	ArgonConfig *ArgonConfig
+	Argon2Config *Argon2Config
 	// Only relevant if S2KMode is set to s2k.IteratedSaltedS2K.
 	// Iteration count for Iterated S2K (String to Key). It
 	// determines the strength of the passphrase stretching when
@@ -37,9 +37,9 @@ type Config struct {
 	S2KCount int
 }
 
-// ArgonConfig stores the Argon2 parameters
-// A nil *ArgonConfig is valid and results in all default
-type ArgonConfig struct {
+// Argon2Config stores the Argon2 parameters
+// A nil *Argon2Config is valid and results in all default
+type Argon2Config struct {
 	NumberOfPasses      uint8
 	DegreeOfParallelism uint8
 	// The memory parameter for Argon2 specifies desired memory usage in kibibytes. 
@@ -62,11 +62,11 @@ func (c *Config) hash() crypto.Hash {
 	return c.Hash
 }
 
-func (c *Config) Argon2() *ArgonConfig {
-	if c == nil || c.ArgonConfig == nil {
+func (c *Config) Argon2() *Argon2Config {
+	if c == nil || c.Argon2Config == nil {
 		return nil
 	}
-	return c.ArgonConfig
+	return c.Argon2Config
 }
 
 // EncodedCount get encoded count
@@ -87,21 +87,21 @@ func (c *Config) EncodedCount() uint8 {
 	return encodeCount(i)
 }
 
-func (c *ArgonConfig) Passes() uint8 {
+func (c *Argon2Config) Passes() uint8 {
 	if c == nil || c.NumberOfPasses == 0 {
 		return 3
 	}
 	return c.NumberOfPasses
 }
 
-func (c *ArgonConfig) Parallelism() uint8 {
+func (c *Argon2Config) Parallelism() uint8 {
 	if c == nil || c.DegreeOfParallelism == 0 {
 		return 4
 	}
 	return c.DegreeOfParallelism
 }
 
-func (c *ArgonConfig) EncodedMemory() uint8 {
+func (c *Argon2Config) EncodedMemory() uint8 {
 	if c == nil || c.Memory == 0 {
 		return 16 // 64 MiB of RAM
 	}

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -57,7 +57,7 @@ var argon2EncodeTest = []struct {
 func TestArgon2EncodeTest(t *testing.T) {
 
 	for i, tests := range argon2EncodeTest {
-		conf  := &ArgonConfig {
+		conf  := &Argon2Config {
 			Memory: tests.in,
 			DegreeOfParallelism: 1,
 		}
@@ -202,7 +202,7 @@ func TestSerializeOK(t *testing.T) {
 }
 
 func TestSerializeOKArgon(t *testing.T) {
-	testSerializeConfigOK(t, &Config{S2KMode: 4, ArgonConfig: &ArgonConfig{NumberOfPasses: 3, DegreeOfParallelism: 4, Memory: 64*1024}})
+	testSerializeConfigOK(t, &Config{S2KMode: 4, Argon2Config: &Argon2Config{NumberOfPasses: 3, DegreeOfParallelism: 4, Memory: 64*1024}})
 }
 
 func testSerializeConfigOK(t *testing.T, c *Config) {

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -86,7 +86,7 @@ func TestArgon2Derive(t *testing.T) {
 	for i, test := range argon2DeriveTests {
 		expected, _ := hex.DecodeString(test.out)
 		out := make([]byte, len(expected))
-		Argon2Derive(out, []byte(test.in), salt[:], 3, 4, 16)
+		Argon2(out, []byte(test.in), salt[:], 3, 4, 16)
 		if !bytes.Equal(expected, out) {
 			t.Errorf("#%d, got: %x want: %x", i, out, expected)
 		}
@@ -127,7 +127,7 @@ func TestParseIntoParams(t *testing.T) {
 
 		if test.params.mode != params.mode || test.params.hashId != params.hashId || test.params.countByte != params.countByte ||
 			!bytes.Equal(test.params.salt, params.salt) {
-			t.Errorf("%d: Wrong s2kconfig, got: %+v want: %+v", i, params, test.params)
+			t.Errorf("%d: Wrong config, got: %+v want: %+v", i, params, test.params)
 		}
 
 		if params.Dummy() != test.dummyKey {
@@ -170,16 +170,16 @@ func TestSerializeOK(t *testing.T) {
 	testCounts := []int{-1, 0, 1024, 65536, 4063232, 65011712}
 	for _, h := range hashes {
 		for _, c := range testCounts {
-			testSerializeConfigOK(t, &S2KConfig{Hash: h, S2KCount: c})
+			testSerializeConfigOK(t, &Config{Hash: h, S2KCount: c})
 		}
 	}
 }
 
 func TestSerializeOKArgon(t *testing.T) {
-	testSerializeConfigOK(t, &S2KConfig{S2KMode: 4, ArgonConf: &ArgonConfig{NumberOfPasses: 3, DegreeOfParallelism: 4, MemoryExponent: 16}})
+	testSerializeConfigOK(t, &Config{S2KMode: 4, ArgonConfig: &ArgonConfig{NumberOfPasses: 3, DegreeOfParallelism: 4, MemoryExponent: 16}})
 }
 
-func testSerializeConfigOK(t *testing.T, c *S2KConfig) {
+func testSerializeConfigOK(t *testing.T, c *Config) {
 	buf := bytes.NewBuffer(nil)
 	key := make([]byte, 16)
 	passphrase := []byte("testing")
@@ -201,7 +201,7 @@ func testSerializeConfigOK(t *testing.T, c *S2KConfig) {
 	}
 }
 
-func testSerializeConfigErr(t *testing.T, c *S2KConfig) {
+func testSerializeConfigErr(t *testing.T, c *Config) {
 	buf := bytes.NewBuffer(nil)
 	key := make([]byte, 16)
 	passphrase := []byte("testing")

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -43,6 +43,32 @@ func TestSalted(t *testing.T) {
 	}
 }
 
+var argon2EncodeTest = []struct {
+	in uint32
+	out uint8
+}{
+	{64*1024, 16},
+	{64*1024+1, 17},
+	{2147483647, 31},
+	{2147483649, 31},
+	{1, 3},
+}
+
+func TestArgon2EncodeTest(t *testing.T) {
+
+	for i, tests := range argon2EncodeTest {
+		conf  := &ArgonConfig {
+			Memory: tests.in,
+			DegreeOfParallelism: 1,
+		}
+		out := conf.EncodedMemory()
+		if out != tests.out {
+			t.Errorf("#%d, got: %x want: %x", i, out, tests.out)
+		}
+	}
+}
+
+
 var iteratedTests = []struct {
 	in, out string
 }{
@@ -176,7 +202,7 @@ func TestSerializeOK(t *testing.T) {
 }
 
 func TestSerializeOKArgon(t *testing.T) {
-	testSerializeConfigOK(t, &Config{S2KMode: 4, ArgonConfig: &ArgonConfig{NumberOfPasses: 3, DegreeOfParallelism: 4, MemoryExponent: 16}})
+	testSerializeConfigOK(t, &Config{S2KMode: 4, ArgonConfig: &ArgonConfig{NumberOfPasses: 3, DegreeOfParallelism: 4, Memory: 64*1024}})
 }
 
 func testSerializeConfigOK(t *testing.T, c *Config) {

--- a/openpgp/test_data/argon2-sym-message.asc
+++ b/openpgp/test_data/argon2-sym-message.asc
@@ -1,0 +1,8 @@
+-----BEGIN PGP MESSAGE-----
+Comment: Encrypted using AES with 128-bit key
+Comment: Session key: 01FE16BBACFD1E7B78EF3B865187374F
+
+wycEBwScUvg8J/leUNU1RA7N/zE2AQQVnlL8rSLPP5VlQsunlO+ECxHSPgGYGKY+
+YJz4u6F+DDlDBOr5NRQXt/KJIf4m4mOlKyC/uqLbpnLJZMnTq3o79GxBTdIdOzhH
+XfA3pqV4mTzF
+-----END PGP MESSAGE-----

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -80,8 +80,8 @@ func TestSignDetachedWithNotation(t *testing.T) {
 	config := &packet.Config{
 		SignatureNotations: []*packet.Notation{
 			{
-				Name:            "test@example.com",
-				Value:           []byte("test"),
+				Name: "test@example.com",
+				Value: []byte("test"),
 				IsHumanReadable: true,
 			},
 		},
@@ -130,10 +130,10 @@ func TestSignDetachedWithCriticalNotation(t *testing.T) {
 	config := &packet.Config{
 		SignatureNotations: []*packet.Notation{
 			{
-				Name:            "test@example.com",
-				Value:           []byte("test"),
+				Name: "test@example.com",
+				Value: []byte("test"),
 				IsHumanReadable: true,
-				IsCritical:      true,
+				IsCritical: true,
 			},
 		},
 	}

--- a/openpgp/write_test.go
+++ b/openpgp/write_test.go
@@ -307,14 +307,14 @@ func TestEncryptWithCompression(t *testing.T) {
 }
 
 func TestSymmetricEncryption(t *testing.T) {
-	modesS2K := map[string]s2k.S2KType{
-		"Iterated": s2k.IterSaltedS2K,
+	modesS2K := map[string]s2k.Mode{
+		"Iterated": s2k.IteratedSaltedS2K,
 		"Argon2":   s2k.Argon2S2K,
 	}
 	for s2kName, s2ktype := range modesS2K {
 		t.Run(s2kName, func(t *testing.T) {
 			config := &packet.Config{
-				S2KConfig: &s2k.S2KConfig{S2KMode: s2ktype},
+				S2KConfig: &s2k.Config{S2KMode: s2ktype},
 			}
 			buf := new(bytes.Buffer)
 			plaintext, err := SymmetricallyEncrypt(buf, []byte("testing"), nil, config)
@@ -351,14 +351,14 @@ func TestSymmetricEncryption(t *testing.T) {
 }
 
 func TestSymmetricEncryptionV5RandomizeSlow(t *testing.T) {
-	modesS2K := map[int]s2k.S2KType{
-		0: s2k.IterSaltedS2K,
+	modesS2K := map[int]s2k.Mode{
+		0: s2k.IteratedSaltedS2K,
 		1: s2k.Argon2S2K,
 	}
 	aeadConf := packet.AEADConfig{
 		DefaultMode: aeadModes[mathrand.Intn(len(aeadModes))],
 	}
-	config := &packet.Config{AEADConfig: &aeadConf, S2KConfig: &s2k.S2KConfig{S2KMode: modesS2K[mathrand.Intn(2)]}}
+	config := &packet.Config{AEADConfig: &aeadConf, S2KConfig: &s2k.Config{S2KMode: modesS2K[mathrand.Intn(2)]}}
 	buf := new(bytes.Buffer)
 	passphrase := make([]byte, mathrand.Intn(maxPassLen))
 	_, err := rand.Read(passphrase)


### PR DESCRIPTION
Adds support for encrypting and decrypting messages or keys with Argon2 S2K as specified in [draft-ietf-openpgp-crypto-refresh](https://datatracker.ietf.org/doc/html/draft-ietf-openpgp-crypto-refresh#section-3.7.1.4).

- Added `Argon2` in the s2k package and refactored it.
- Introduces a new field `S2KConfig` in `packet.Config` that allows configuring S2K. All configurations for S2K should now be done via an S2K configuration linked in this field. The config remains backward compatible to setting `S2KCount` directly in `packet.Config`.
- The public `Encrypt` method exposed in `packet.PrivateKey` for encrypting keys currently does not allow configuring S2K and defaults to the Iterative mode. There is now a private function that allows configuration. (Should be adapted in the future)
