### PR TITLE
Only check hash prefix for v5 signatures

### DIFF
--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -596,7 +596,7 @@ func (pk *PublicKey) VerifySignature(signed hash.Hash, sig *Signature) (err erro
 	}
 	signed.Write(sig.HashSuffix)
 	hashBytes := signed.Sum(nil)
-	if hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1] {
+	if sig.Version == 5 && (hashBytes[0] != sig.HashTag[0] || hashBytes[1] != sig.HashTag[1]) {
 		return errors.SignatureError("hash tag doesn't match")
 	}
 


### PR DESCRIPTION
Closes #107

Note that this follows the convention elsewhere in the same function where we only check for `sig.Version == 5` and not `sig.Version >= 5`; this will have to be updated for v6 compatibility but this PR is not the place for that change (or is it?).