### PR TITLE
Allow using SaltedS2K with high entropy keys

### DIFF
--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -81,6 +81,7 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 	}
 
 	modesS2K := map[string]s2k.Mode{
+		"Salted":   s2k.SaltedS2K,
 		"Iterated": s2k.IteratedSaltedS2K,
 		"Argon2":   s2k.Argon2S2K,
 	}
@@ -97,7 +98,7 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 							config := &Config{
 								DefaultCipher: cipher,
 								AEADConfig:    &AEADConfig{DefaultMode: mode},
-								S2KConfig:     &s2k.Config{S2KMode: s2ktype},
+								S2KConfig:     &s2k.Config{S2KMode: s2ktype, HighEntropyKey: true},
 							}
 
 							key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
@@ -133,6 +134,7 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 	}
 
 	testS2K := map[string]s2k.Mode{
+		"Salted":   s2k.SaltedS2K,
 		"Iterated": s2k.IteratedSaltedS2K,
 		"Argon2":   s2k.Argon2S2K,
 	}
@@ -150,6 +152,7 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 						DefaultCipher: cipher,
 						S2KConfig: &s2k.Config{
 							S2KMode: s2ktype,
+							HighEntropyKey: true,
 						},
 					}
 

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -98,7 +98,7 @@ func TestSerializeSymmetricKeyEncryptedV5RandomizeSlow(t *testing.T) {
 							config := &Config{
 								DefaultCipher: cipher,
 								AEADConfig:    &AEADConfig{DefaultMode: mode},
-								S2KConfig:     &s2k.Config{S2KMode: s2ktype, HighEntropyKey: true},
+								S2KConfig:     &s2k.Config{S2KMode: s2ktype, PassphraseIsHighEntropy: true},
 							}
 
 							key, err := SerializeSymmetricKeyEncrypted(&buf, passphrase, config)
@@ -152,7 +152,7 @@ func TestSerializeSymmetricKeyEncryptedCiphersV4(t *testing.T) {
 						DefaultCipher: cipher,
 						S2KConfig: &s2k.Config{
 							S2KMode: s2ktype,
-							HighEntropyKey: true,
+							PassphraseIsHighEntropy: true,
 						},
 					}
 

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -192,13 +192,21 @@ func Generate(rand io.Reader, c *Config) (*Params, error) {
 			parallelism: argonConfig.Parallelism(),
 			memoryExp:   argonConfig.EncodedMemory(),
 		}
-	} else {
-		// handle IteratedSaltedS2K case
+	} else if c != nil && c.HighEntropyKey && c.Mode() == SaltedS2K { // Allow SaltedS2K if HighEntropyKey
 		hashId, ok := algorithm.HashToHashId(c.hash())
 		if !ok {
 			return nil, errors.UnsupportedError("no such hash")
 		}
-		// Enforce iterared + salted method if not Argon 2
+
+		params = &Params{
+			mode:      SaltedS2K,
+			hashId:    hashId,
+		}
+	} else { // Enforce IteratedSaltedS2K method otherwise
+		hashId, ok := algorithm.HashToHashId(c.hash())
+		if !ok {
+			return nil, errors.UnsupportedError("no such hash")
+		}
 		if c != nil {
 			c.S2KMode = IteratedSaltedS2K
 		}

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -192,7 +192,7 @@ func Generate(rand io.Reader, c *Config) (*Params, error) {
 			parallelism: argonConfig.Parallelism(),
 			memoryExp:   argonConfig.EncodedMemory(),
 		}
-	} else if c != nil && c.HighEntropyKey && c.Mode() == SaltedS2K { // Allow SaltedS2K if HighEntropyKey
+	} else if c != nil && c.PassphraseIsHighEntropy && c.Mode() == SaltedS2K { // Allow SaltedS2K if PassphraseIsHighEntropy
 		hashId, ok := algorithm.HashToHashId(c.hash())
 		if !ok {
 			return nil, errors.UnsupportedError("no such hash")

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -8,7 +8,8 @@ import "crypto"
 type Config struct {
 	// S2K (String to Key) mode, used for key derivation in the context of secret key encryption
 	// and password-encrypted data. Either s2k.Argon2S2K or s2k.IteratedSaltedS2K has to be selected
-	// weaker options are not allowed.
+	// weaker options are not allowed. For high-entropy keys, s2k.SaltedS2K can also be selected,
+	// if the parameter HighEntropyKey is set to true.
 	// Note: Argon2 is the strongest option but not all OpenPGP implementations are compatible with it
 	//(pending standardisation).
 	// 0 (simple), 1(salted), 3(iterated), 4(argon2)
@@ -35,6 +36,11 @@ type Config struct {
 	// use a value that is at least 65536. See RFC 4880 Section
 	// 3.7.1.3.
 	S2KCount int
+	// When true, allows the S2KMode to be s2k.SaltedS2K.
+	// This is required to ensure the application is aware that a weaker
+	// S2K is being selected, and is only being used when the key has
+	// been randomly generated or a secure S2K has already been applied.
+	HighEntropyKey bool
 }
 
 // Argon2Config stores the Argon2 parameters

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// When true, allows the S2KMode to be s2k.SaltedS2K.
 	// When the passphrase is not a high-entropy key, using SaltedS2K is
 	// insecure, and not allowed by draft-ietf-openpgp-crypto-refresh-08.
-	HighEntropyKey bool
+	PassphraseIsHighEntropy bool
 }
 
 // Argon2Config stores the Argon2 parameters

--- a/openpgp/s2k/s2k_config.go
+++ b/openpgp/s2k/s2k_config.go
@@ -7,9 +7,9 @@ import "crypto"
 // values.
 type Config struct {
 	// S2K (String to Key) mode, used for key derivation in the context of secret key encryption
-	// and password-encrypted data. Either s2k.Argon2S2K or s2k.IteratedSaltedS2K has to be selected
-	// weaker options are not allowed. For high-entropy keys, s2k.SaltedS2K can also be selected,
-	// if the parameter HighEntropyKey is set to true.
+	// and passphrase-encrypted data. Either s2k.Argon2S2K or s2k.IteratedSaltedS2K may be used.
+	// If the passphrase is a high-entropy key, indicated by setting PassphraseIsHighEntropy to true,
+	// s2k.SaltedS2K can also be used.
 	// Note: Argon2 is the strongest option but not all OpenPGP implementations are compatible with it
 	//(pending standardisation).
 	// 0 (simple), 1(salted), 3(iterated), 4(argon2)
@@ -36,10 +36,12 @@ type Config struct {
 	// use a value that is at least 65536. See RFC 4880 Section
 	// 3.7.1.3.
 	S2KCount int
+	// Indicates whether the passphrase passed by the application is a
+	// high-entropy key (e.g. it's randomly generated or derived from
+	// another passphrase using a strong key derivation function).
 	// When true, allows the S2KMode to be s2k.SaltedS2K.
-	// This is required to ensure the application is aware that a weaker
-	// S2K is being selected, and is only being used when the key has
-	// been randomly generated or a secure S2K has already been applied.
+	// When the passphrase is not a high-entropy key, using SaltedS2K is
+	// insecure, and not allowed by draft-ietf-openpgp-crypto-refresh-08.
 	HighEntropyKey bool
 }
 

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -194,7 +194,7 @@ func TestSerializeSaltedOK(t *testing.T) {
 	hashes := []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512, crypto.SHA224, crypto.SHA3_256,
 		crypto.SHA3_512}
 	for _, h := range hashes {
-		params := testSerializeConfigOK(t, &Config{S2KMode: SaltedS2K, Hash: h, HighEntropyKey: true})
+		params := testSerializeConfigOK(t, &Config{S2KMode: SaltedS2K, Hash: h, PassphraseIsHighEntropy: true})
 
 		if params.mode != SaltedS2K {
 			t.Fatalf("Wrong mode, expected %d got %d", SaltedS2K, params.mode)

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -190,50 +190,91 @@ func TestParseIntoParams(t *testing.T) {
 	}
 }
 
-func TestSerializeOK(t *testing.T) {
+func TestSerializeSaltedOK(t *testing.T) {
 	hashes := []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512, crypto.SHA224, crypto.SHA3_256,
 		crypto.SHA3_512}
-	testCounts := []int{-1, 0, 1024, 65536, 4063232, 65011712}
+	for _, h := range hashes {
+		params := testSerializeConfigOK(t, &Config{S2KMode: SaltedS2K, Hash: h, HighEntropyKey: true})
+
+		if params.mode != SaltedS2K {
+			t.Fatalf("Wrong mode, expected %d got %d", SaltedS2K, params.mode)
+		}
+	}
+}
+
+func TestSerializeSaltedLowEntropy(t *testing.T) {
+	hashes := []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512, crypto.SHA224, crypto.SHA3_256,
+		crypto.SHA3_512}
+	for _, h := range hashes {
+		params := testSerializeConfigOK(t, &Config{S2KMode: SaltedS2K, Hash: h})
+
+		if params.mode != IteratedSaltedS2K {
+			t.Fatalf("Wrong mode, expected %d got %d", IteratedSaltedS2K, params.mode)
+		}
+
+		if params.countByte != 224 { // The default case. Corresponding to 16777216
+			t.Fatalf("Wrong count byte, expected %d got %d", 224, params.countByte)
+		}
+	}
+}
+
+func TestSerializeSaltedIteratedOK(t *testing.T) {
+	hashes := []crypto.Hash{crypto.SHA256, crypto.SHA384, crypto.SHA512, crypto.SHA224, crypto.SHA3_256,
+		crypto.SHA3_512}
+	// {input, expected}
+	testCounts := [][]int{{-1, 96}, {0, 224}, {1024, 96}, {65536, 96}, {4063232, 191}, {65011712, 255}}
 	for _, h := range hashes {
 		for _, c := range testCounts {
-			testSerializeConfigOK(t, &Config{Hash: h, S2KCount: c})
+			params := testSerializeConfigOK(t, &Config{Hash: h, S2KCount: c[0]})
+
+			if params.mode != IteratedSaltedS2K {
+				t.Fatalf("Wrong mode, expected %d got %d", IteratedSaltedS2K, params.mode)
+			}
+
+			if int(params.countByte) != c[1] {
+				t.Fatalf("Wrong count byte, expected %d got %d", c[1], params.countByte)
+			}
 		}
 	}
 }
 
 func TestSerializeOKArgon(t *testing.T) {
-	testSerializeConfigOK(t, &Config{S2KMode: 4, Argon2Config: &Argon2Config{NumberOfPasses: 3, DegreeOfParallelism: 4, Memory: 64*1024}})
+	config := &Config{
+		S2KMode: Argon2S2K,
+		Argon2Config: &Argon2Config{NumberOfPasses: 3, DegreeOfParallelism: 4, Memory: 64*1024},
+	}
+
+	params := testSerializeConfigOK(t, config)
+
+	if params.mode != Argon2S2K {
+		t.Fatalf("Wrong mode, expected %d got %d", Argon2S2K, params.mode)
+	}
 }
 
-func testSerializeConfigOK(t *testing.T, c *Config) {
+func testSerializeConfigOK(t *testing.T, c *Config) *Params {
 	buf := bytes.NewBuffer(nil)
 	key := make([]byte, 16)
 	passphrase := []byte("testing")
 	err := Serialize(buf, key, rand.Reader, passphrase, c)
 	if err != nil {
-		t.Errorf("failed to serialize with config %+v: %s", c, err)
-		return
+		t.Fatalf("failed to serialize with config %+v: %s", c, err)
 	}
 
-	f, err := Parse(buf)
+	f, err := Parse(bytes.NewBuffer(buf.Bytes()))
 	if err != nil {
-		t.Errorf("failed to reparse: %s", err)
-		return
+		t.Fatalf("failed to reparse: %s", err)
 	}
 	key2 := make([]byte, len(key))
 	f(key2, passphrase)
 	if !bytes.Equal(key2, key) {
 		t.Errorf("keys don't match: %x (serialied) vs %x (parsed)", key, key2)
 	}
+
+	params, err := ParseIntoParams(bytes.NewBuffer(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("failed to parse params: %s", err)
+	}
+
+	return params
 }
 
-func testSerializeConfigErr(t *testing.T, c *Config) {
-	buf := bytes.NewBuffer(nil)
-	key := make([]byte, 16)
-	passphrase := []byte("testing")
-	err := Serialize(buf, key, rand.Reader, passphrase, c)
-	if err == nil {
-		t.Errorf("expected to fail serialization with config %+v", c)
-		return
-	}
-}


### PR DESCRIPTION
- Add `HighEntropyKey` configuration parameter to S2K
- Allow generation of `SaltedS2K` params for high entropy keys
- Add parsing tests