### PR TITLE
Truncate config.Now to second precision

### DIFF
--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -123,7 +123,7 @@ func TestExpiringPrimaryUIDKey(t *testing.T) {
 	}
 }
 
-func TestReturnFirstUnexpiredSigningSubkey(t *testing.T) {
+func TestReturnNewestUnexpiredSigningSubkey(t *testing.T) {
 	// Make a master key.
 	entity, err := NewEntity("Golang Gopher", "Test Key", "no-reply@golang.com", nil)
 	if err != nil {
@@ -140,6 +140,9 @@ func TestReturnFirstUnexpiredSigningSubkey(t *testing.T) {
 
 	// Second signing subkey expires in a day.
 	err = entity.AddSigningSubkey(&packet.Config{
+		Time: func() time.Time {
+			return time.Now().Add(1 * time.Second)
+		},
 		KeyLifetimeSecs: 24 * 60 * 60,
 	})
 	if err != nil {
@@ -149,7 +152,7 @@ func TestReturnFirstUnexpiredSigningSubkey(t *testing.T) {
 	subkey2 := entity.Subkeys[2]
 
 	// Before second signing subkey has expired, it should be returned.
-	time1 := time.Now()
+	time1 := time.Now().Add(2 * time.Second)
 	expected := subkey2.PublicKey.KeyIdShortString()
 	subkey, found := entity.SigningKey(time1)
 	if !found {

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	// and password-encrypted data.
 	// If nil, the default configuration is used
 	S2KConfig *s2k.Config
-	// Iteration count for Iterated S2K (String to Key). 
+	// Iteration count for Iterated S2K (String to Key).
 	// Only used if sk2.Mode is nil.
 	// This value is duplicated here from s2k.Config for backwards compatibility.
 	// It determines the strength of the passphrase stretching when
@@ -135,9 +135,9 @@ func (c *Config) Cipher() CipherFunction {
 
 func (c *Config) Now() time.Time {
 	if c == nil || c.Time == nil {
-		return time.Now()
+		return time.Now().Truncate(time.Second)
 	}
-	return c.Time()
+	return c.Time().Truncate(time.Second)
 }
 
 // KeyLifetime returns the validity period of the key.
@@ -198,7 +198,7 @@ func (c *Config) S2K() *s2k.Config {
 	}
 	// for backwards compatibility
 	if c != nil && c.S2KCount > 0 && c.S2KConfig == nil {
-		return &s2k.Config {
+		return &s2k.Config{
 			S2KCount: c.S2KCount,
 		}
 	}


### PR DESCRIPTION
Because pgp uses seconds and not ns.

For(alternative) to https://github.com/ProtonMail/gopenpgp/pull/240