### PR TITLE
Ensure crypto refresh cleartext messages are parseable

### DIFF
--- a/openpgp/clearsign/clearsign.go
+++ b/openpgp/clearsign/clearsign.go
@@ -127,12 +127,14 @@ func Decode(data []byte) (b *Block, rest []byte) {
 
 		key, val := string(line[0:i]), string(line[i+1:])
 		key = strings.TrimSpace(key)
-		if key != "Hash" {
+		if key != "Hash" && key != "SaltedHash" {
 			return nil, data
 		}
-		for _, val := range strings.Split(val, ",") {
-			val = strings.TrimSpace(val)
-			b.Headers.Add(key, val)
+		if key == "Hash" {
+			for _, val := range strings.Split(val, ",") {
+				val = strings.TrimSpace(val)
+				b.Headers.Add(key, val)
+			}
 		}
 	}
 


### PR DESCRIPTION
The crypto refresh introduces a new `SaltedHash` header in signed cleartext messages, which prevents a new message from being parsed by the library. This pull request updates the parsing function to accept the new header and ensures that a cleartext message containing multiple signatures with different versions can be verified.

For example, the following cleartext message with a v4 and  a v6 signature
can now be successfully verified with a v4 key.
```
-----BEGIN PGP SIGNED MESSAGE-----
SaltedHash: SHA512:MOvqfCOPw2ONdPPtEzWRHPrtHV7jge6f7/iBUI7FqQQ
Hash: SHA512

....

-----BEGIN PGP SIGNATURE-----
...
-----END PGP SIGNATURE-----
```