### PR TITLE
Update armor.go

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -209,9 +209,17 @@ TryNextBlock:
 		}
 
 		i := bytes.Index(line, []byte(": "))
-		if i == -1 {
-			goto TryNextBlock
-		}
+                if i == -1 {
+                // Check if the line is empty
+                if len(line) == 0 {
+                goto TryNextBlock
+                }
+                // Check if the line contains only whitespace characters
+                if bytes.TrimSpace(line) == nil {
+                goto TryNextBlock
+                }
+                }
+
 		lastKey = string(line[:i])
 		p.Header[lastKey] = string(line[i+2:])
 	}


### PR DESCRIPTION
Non empty line being parsed as a header fix. By adding a check for an empty line or a line containing only whitespace characters, it is ensured that the library will ignore such lines and proceed with decoding the rest of the armored data rather than trying to parse it as a header or find a new block