### PR TITLE
Make armor decode more robust to empty header values

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -10,8 +10,9 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
-	"github.com/ProtonMail/go-crypto/openpgp/errors"
 	"io"
+
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
 )
 
 // A Block represents an OpenPGP armored structure.
@@ -208,12 +209,16 @@ TryNextBlock:
 			break
 		}
 
-		i := bytes.Index(line, []byte(": "))
+		i := bytes.Index(line, []byte(":"))
 		if i == -1 {
 			goto TryNextBlock
 		}
 		lastKey = string(line[:i])
-		p.Header[lastKey] = string(line[i+2:])
+		var value string
+		if len(line) > i+2 {
+			value = string(line[i+2:])
+		}
+		p.Header[lastKey] = value
 	}
 
 	p.lReader.in = r

--- a/openpgp/armor/armor_test.go
+++ b/openpgp/armor/armor_test.go
@@ -54,6 +54,25 @@ func TestDecodeEncode(t *testing.T) {
 	}
 }
 
+func TestDecodeEmptyVersion(t *testing.T) {
+	buf := bytes.NewBuffer([]byte(armorExampleEmptyVersion))
+	result, err := Decode(buf)
+	if err != nil {
+		t.Error(err)
+	}
+	expectedType := "PGP SIGNATURE"
+	if result.Type != expectedType {
+		t.Errorf("result.Type: got:%s want:%s", result.Type, expectedType)
+	}
+	if len(result.Header) != 1 {
+		t.Errorf("len(result.Header): got:%d want:1", len(result.Header))
+	}
+	v, ok := result.Header["Version"]
+	if !ok || v != "" {
+		t.Errorf("result.Header: got:%#v", result.Header)
+	}
+}
+
 func TestLongHeader(t *testing.T) {
 	buf := bytes.NewBuffer([]byte(armorLongLine))
 	result, err := Decode(buf)
@@ -93,3 +112,20 @@ okWuf3+xA9ksp1npSY/mDvgHijmjvtpRDe6iUeqfCn8N9u9CBg8geANgaG8+QA4=
 -----END PGP SIGNATURE-----`
 
 const longValueExpected = "0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"
+
+const armorExampleEmptyVersion = `-----BEGIN PGP SIGNATURE-----
+Version: 
+
+wsE7BAABCgBvBYJkbfmWCRD7/MgqAV5zMEcUAAAAAAAeACBzYWx0QG5vdGF0aW9u
+cy5zZXF1b2lhLXBncC5vcmeMXzsJEgIm228SdxV22XgYny4adwqEgyIT9UL3F92C
+OhYhBNGmbhojsYLJmA94jPv8yCoBXnMwAAAj1AwAiSkJPxsEcyaoYWbxc657xPW1
+MlrbNhDBIWpKVrqQgyz7NdDZvvY0Ty+/h62HK5GQ5obAzVmQVwtUVG950TxCksg1
+F18mqticpxg1veZQdw7DBYTk0RJTpdVBRYJ5UOtHaSJUAnqGh7OQE6Lu74vfFhNv
+dDjpjgEc6TnJrEBOOR7+RVp7+0i4HhM3+JdfSOMMOEb6ixWEYLtfC2Zd/p0f7vP8
+tHiqllDXDbfBCXlFl5h2LAh39o/LE0vZvwf+C9i9PgRARawWIh+xeAJsVne8FZ12
+FD+hWZJdNUCv4iE1H7QDVv8nuPAz3WB/DQWNSfeGTZnN+ouB1cjPFscBuunO5Dss
+k3hXy+XB5mZW6iisjUnUBknJEa43AMX+zGSaGHljEgfTGLbgEK+deOhPqKEkhUKr
+/VlIVBXgfjQuoizme9S9juxXHdDHa+Y5Wb9rTUc1y9YPArRem51VI0OzbJ2cRnLH
+J0YF6lYvjcTVBtmQlYeOfZsz4EABEeBYe/rbDmJC
+=b+IB
+-----END PGP SIGNATURE-----`


### PR DESCRIPTION
This pull request adapts `armor.Decode` to allow empty values in headers.
Messages of the following form can now be parsed:

```
-----BEGIN PGP SIGNATURE-----
Version: 
...
-----END PGP SIGNATURE-----`
```