### PR TITLE
fix: IssuerKeyId non-critical

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -904,7 +904,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey) (subpackets []outputSubp
 	if sig.IssuerKeyId != nil && sig.Version == 4 {
 		keyId := make([]byte, 8)
 		binary.BigEndian.PutUint64(keyId, *sig.IssuerKeyId)
-		subpackets = append(subpackets, outputSubpacket{true, issuerSubpacket, true, keyId})
+		subpackets = append(subpackets, outputSubpacket{true, issuerSubpacket, false, keyId})
 	}
 	if sig.IssuerFingerprint != nil {
 		contents := append([]uint8{uint8(issuer.Version)}, sig.IssuerFingerprint...)


### PR DESCRIPTION
So, let me start by saying I'm not crypto/gpg expert or anything. If this is wrong, I'd appreciate being pointed to the right direction 🙏

I maintain nFPM and GoReleaser, and, when golang.org/x/crypto was deprecated, I switched to your fork.

On commit cc34b1f it broke signatures for RPM versions, so I locked into the previous commit (c05353c).

After some time, I noticed that the latest commit (at the time, and now too) works RPM 4.17+ too.

I have been postponing investigating this properly for a couple of years (I think), today I finally went down the rabbit hole:

- created tests signing and checking on several versions of fedora and centos, ranging RPM 4.14 - 4.18
- made a sort of manual bisect of this project trying to find which commit fixed 4.17 so I could try to fix for other versions too

Finally, found it: a4f6767

It was the clue I needed to try to fix the whatever else is broken.

Then, through git blame, I found aef62243dce8452451d6dd6c009b22c58a6a50fa, which adds v5 signatures, but also changes the Issuer Key ID packet to critical on v4.

Change: https://github.com/ProtonMail/go-crypto/commit/aef62243dce8452451d6dd6c009b22c58a6a50fa#diff-65b30b147e6c8432806b9ff7fa5f3368af59ccbd942e99582137fa0cd46978f6L782

I'm not sure if that particular change is intentional or not, but reverting it (making issue key id non-critical in v4) fixes everything for all RPM versions.

Again, I don't know if this is correct per GPG spec and RPM is wrong, or the other way around, or something else, all I know is that this seems to fix thing and doesn't seem to break any tests.

Thanks for your time, and sorry about this whole novel of a writing.

Happy weekend!