### PR TITLE
Add openpgp option to ignore Signature and Key Expiration

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	// Time returns the current time as the number of seconds since the
 	// epoch. If Time is nil, time.Now is used.
 	Time func() time.Time
+	// Ignore Key Expiration, some clients may not care about expiration
+	IgnoreKeyExpiration bool
+	// Ignore Signature Expiration, some clients may not care about expiration
+	IgnoreSignatureExpiration bool
 	// DefaultCompressionAlgo is the compression algorithm to be
 	// applied to the plaintext before encryption. If zero, no
 	// compression is done.

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -433,6 +433,11 @@ func TestDetachedSignatureExpiredCrossSig(t *testing.T) {
 	if err != errors.ErrSignatureExpired {
 		t.Fatalf("Unexpected class of error: %s", err)
 	}
+	config.IgnoreSignatureExpiration = true
+	_, err = CheckArmoredDetachedSignature(kring, bytes.NewBufferString("Hello World :)"), bytes.NewBufferString(sigFromKeyWithExpiredCrossSig), config)
+	if err != nil {
+		t.Fatalf("Expected signature expiration check to be skipped")
+	}
 }
 
 func TestSignatureUnknownNotation(t *testing.T) {


### PR DESCRIPTION
This change allows libraries which don't check/care about expiration to bypass this logic without relying on internal implementation details of go-crypto.