### PR TITLE
Remove VerifyDetachedSignatureAndSaltedHash and SaltedHashSpecifier

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -127,13 +127,6 @@ type VerifiableSignature struct {
 	Packet *Signature
 }
 
-// SaltedHashSpecifier specifies that the given salt and hash are
-// used by a v6 signature.
-type SaltedHashSpecifier struct {
-	Hash crypto.Hash
-	Salt []byte
-}
-
 // NewVerifiableSig returns a struct of type VerifiableSignature referencing the input signature.
 func NewVerifiableSig(signature *Signature) *VerifiableSignature {
 	return &VerifiableSignature{

--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -669,7 +669,6 @@ func VerifyDetachedSignature(keyring KeyRing, signed, signature io.Reader, confi
 // Once all data is read from md.UnverifiedBody the detached signature is verified.
 // If a verification error occurs it is stored in md.SignatureError
 // If the signer isn't known, ErrUnknownIssuer is returned.
-// if they match the signatures metadata or else return an error
 func VerifyDetachedSignatureReader(keyring KeyRing, signed, signature io.Reader, config *packet.Config) (md *MessageDetails, err error) {
 	return verifyDetachedSignatureReader(keyring, signed, signature, config)
 }

--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -669,7 +669,6 @@ func VerifyDetachedSignature(keyring KeyRing, signed, signature io.Reader, confi
 // Once all data is read from md.UnverifiedBody the detached signature is verified.
 // If a verification error occurs it is stored in md.SignatureError
 // If the signer isn't known, ErrUnknownIssuer is returned.
-// If expectedHashes or expectedSaltedHashes is not nil, the method checks
 // if they match the signatures metadata or else return an error
 func VerifyDetachedSignatureReader(keyring KeyRing, signed, signature io.Reader, config *packet.Config) (md *MessageDetails, err error) {
 	return verifyDetachedSignatureReader(keyring, signed, signature, config)


### PR DESCRIPTION
This pull request removes the `openpgp.VerifyDetachedSignatureAndSaltedHash` function and the `packet.SaltedHashSpecifier` as they are not required anymore. They were introduced for verifying the headers in cleartext messages. However, in the latest crypto refresh specification, cleartext message headers were dropped.