### PR TITLE
Fix session key length generation

### DIFF
--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -664,7 +664,12 @@ func encrypt(
 	}
 
 	if params.SessionKey == nil {
-		params.SessionKey = make([]byte, cipher.KeySize())
+		if aeadSupported {
+			params.SessionKey = make([]byte, aeadCipherSuite.Cipher.KeySize())
+		} else {
+			params.SessionKey = make([]byte, cipher.KeySize())
+		}
+
 		if _, err := io.ReadFull(config.Random(), params.SessionKey); err != nil {
 			return nil, err
 		}

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -444,7 +444,13 @@ func encrypt(keyWriter io.Writer, dataWriter io.Writer, to []*Entity, signed *En
 		}
 	}
 
-	symKey := make([]byte, cipher.KeySize())
+	var symKey []byte
+	if aeadSupported {
+		symKey = make([]byte, aeadCipherSuite.Cipher.KeySize())
+	} else {
+		symKey = make([]byte, cipher.KeySize())
+	}
+
 	if _, err := io.ReadFull(config.Random(), symKey); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If AEAD is in use, we should generate a session key of the length of the cipher suite. This triggers when a key has a different AEAD preference than the cipher.