### PR TITLE
New feature: Added the function `NewEntityFromKey` that allows passing pre-created RSA or ECDSA keys.

### DIFF
--- a/openpgp/key_wrap.go
+++ b/openpgp/key_wrap.go
@@ -1,0 +1,102 @@
+package openpgp
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/ProtonMail/go-crypto/openpgp/internal/ecc"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+
+	internalecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
+)
+
+// NewEntity returns an Entity that contains either a RSA or ECDSA keypair
+// passed by the user with a single identity composed of the given full name,
+// comment and email, any of which may be empty but must not contain any of
+// "()<>\x00". If config is nil, sensible defaults will be used. It is not
+// required to assign any of the key type parameters in the config (in fact,
+// they will be ignored); these will be set based on the passed key.
+func NewEntityFromKey(name, comment, email string, key crypto.PrivateKey, config *packet.Config) (*Entity, error) {
+	creationTime := config.Now()
+	keyLifetimeSecs := config.KeyLifetime()
+
+	primaryPrivRaw, err := newSignerFromKey(key, config)
+	if err != nil {
+		return nil, err
+	}
+	primary := packet.NewSignerPrivateKey(creationTime, primaryPrivRaw)
+	if config.V6() {
+		primary.UpgradeToV6()
+	}
+
+	e := &Entity{
+		PrimaryKey: &primary.PublicKey,
+		PrivateKey: primary,
+		Identities: make(map[string]*Identity),
+		Subkeys:    []Subkey{},
+		Signatures: []*packet.Signature{},
+	}
+
+	if config.V6() {
+		// In v6 keys algorithm preferences should be stored in direct key signatures
+		selfSignature := createSignaturePacket(&primary.PublicKey, packet.SigTypeDirectSignature, config)
+		err = writeKeyProperties(selfSignature, creationTime, keyLifetimeSecs, config)
+		if err != nil {
+			return nil, err
+		}
+		err = selfSignature.SignDirectKeyBinding(&primary.PublicKey, primary, config)
+		if err != nil {
+			return nil, err
+		}
+		e.Signatures = append(e.Signatures, selfSignature)
+		e.SelfSignature = selfSignature
+	}
+
+	err = e.addUserId(name, comment, email, config, creationTime, keyLifetimeSecs, !config.V6())
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: No key expiry here, but we will not return this subkey in EncryptionKey()
+	// if the primary/master key has expired.
+	err = e.addEncryptionSubkey(config, creationTime, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return e, nil
+}
+
+func newSignerFromKey(key crypto.PrivateKey, config *packet.Config) (interface{}, error) {
+	switch key := key.(type) {
+	case *rsa.PrivateKey:
+		config.Algorithm = packet.PubKeyAlgoRSA
+		return key, nil
+	case *ecdsa.PrivateKey:
+		var c ecc.ECDSACurve
+		switch key.Curve {
+		case elliptic.P256():
+			c = ecc.NewGenericCurve(elliptic.P256())
+			config.Curve = packet.CurveNistP256
+		case elliptic.P384():
+			c = ecc.NewGenericCurve(elliptic.P384())
+			config.Curve = packet.CurveNistP384
+		case elliptic.P521():
+			c = ecc.NewGenericCurve(elliptic.P521())
+			config.Curve = packet.CurveNistP521
+		default:
+			return nil, errors.InvalidArgumentError("unsupported elliptic curve")
+		}
+		priv := internalecdsa.NewPrivateKey(
+			*internalecdsa.NewPublicKey(c),
+		)
+		priv.PublicKey.X, priv.PublicKey.Y, priv.D = key.X, key.Y, key.D
+		config.Algorithm = packet.PubKeyAlgoECDSA
+		return priv, nil
+	default:
+		return nil, errors.InvalidArgumentError("unsupported public key algorithm")
+	}
+}


### PR DESCRIPTION
The objective of this PR is to add the possibility of passing pre-created RSA or ECDSA keys, possibly coming from deterministic sources such as used in key derivation. The conversion of other elliptic curves from standard Go `crypto` to `openpgp` supported ones is a possible extension to this PR, such as `crypto/ed25519`, but I'm not really sure yet if they would be compatible.