### PR TITLE
fix several semgrep lint errors

### DIFF
--- a/openpgp/packet/aead_crypter.go
+++ b/openpgp/packet/aead_crypter.go
@@ -173,10 +173,7 @@ func (ar *aeadDecrypter) validateFinalTag(tag []byte) error {
 	adata = append(adata, amountBytes...)
 	nonce := ar.computeNextNonce()
 	_, err := ar.aead.Open(nil, nonce, tag, adata)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // aeadEncrypter encrypts and writes bytes. It encrypts when necessary according

--- a/openpgp/packet/compressed.go
+++ b/openpgp/packet/compressed.go
@@ -9,7 +9,6 @@ import (
 	"compress/flate"
 	"compress/zlib"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	"github.com/ProtonMail/go-crypto/openpgp/errors"
@@ -91,7 +90,7 @@ func (c *Compressed) parse(r io.Reader) error {
 		}
 		c.Body = newDecompressionReader(r, decompressor)
 	case 3:
-		c.Body = newDecompressionReader(r, ioutil.NopCloser(bzip2.NewReader(r)))
+		c.Body = newDecompressionReader(r, io.NopCloser(bzip2.NewReader(r)))
 	default:
 		err = errors.UnsupportedError("unknown compression algorithm: " + strconv.Itoa(int(buf[0])))
 	}

--- a/openpgp/packet/padding.go
+++ b/openpgp/packet/padding.go
@@ -2,7 +2,6 @@ package packet
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 // Padding type represents a Padding Packet (Tag 21).
@@ -12,7 +11,7 @@ type Padding int
 
 // parse just ignores the padding content.
 func (pad Padding) parse(reader io.Reader) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(pad))
+	_, err := io.CopyN(io.Discard, reader, int64(pad))
 	return err
 }
 

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -590,10 +590,7 @@ func (pk *PublicKey) SerializeSignaturePrefix(w io.Writer) error {
 			byte(pLength >> 8),
 			byte(pLength),
 		})
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	}
 	if _, err := w.Write([]byte{0x99, byte(pLength >> 8), byte(pLength)}); err != nil {
 		return err

--- a/openpgp/packet/symmetrically_encrypted_mdc.go
+++ b/openpgp/packet/symmetrically_encrypted_mdc.go
@@ -241,9 +241,6 @@ func serializeSymmetricallyEncryptedMdc(ciphertext io.WriteCloser, c CipherFunct
 	if err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return
-	}
 	s, prefix := NewOCFBEncrypter(block, iv, OCFBNoResync)
 	_, err = ciphertext.Write(prefix)
 	if err != nil {


### PR DESCRIPTION
PR fixes a few errors flagged by semgrep scan using the [semgrep-go](https://github.com/dgryski/semgrep-go) ruleset.