### PR TITLE
ECDH with v6 must use the full fingerprint

### DIFF
--- a/openpgp/ecdh/ecdh.go
+++ b/openpgp/ecdh/ecdh.go
@@ -163,8 +163,7 @@ func buildKey(pub *PublicKey, zb []byte, curveOID, fingerprint []byte, stripLead
 	if _, err := param.Write([]byte("Anonymous Sender    ")); err != nil {
 		return nil, err
 	}
-	// For v5 keys, the 20 leftmost octets of the fingerprint are used.
-	if _, err := param.Write(fingerprint[:20]); err != nil {
+	if _, err := param.Write(fingerprint[:]); err != nil {
 		return nil, err
 	}
 	if param.Len()-len(curveOID) != 45 {

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -233,7 +233,7 @@ func (c *Config) S2K() *s2k.Config {
 		return nil
 	}
 	// for backwards compatibility
-	if c != nil && c.S2KCount > 0 && c.S2KConfig == nil {
+	if c.S2KCount > 0 && c.S2KConfig == nil {
 		return &s2k.Config{
 			S2KCount: c.S2KCount,
 		}

--- a/openpgp/packet/encrypted_key.go
+++ b/openpgp/packet/encrypted_key.go
@@ -181,7 +181,12 @@ func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
 		vsG := e.encryptedMPI1.Bytes()
 		m := e.encryptedMPI2.Bytes()
 		oid := priv.PublicKey.oid.EncodedBytes()
-		b, err = ecdh.Decrypt(priv.PrivateKey.(*ecdh.PrivateKey), vsG, m, oid, priv.PublicKey.Fingerprint[:])
+		fp := priv.PublicKey.Fingerprint[:]
+		if priv.PublicKey.Version == 5 {
+			// For v5 the, the fingerprint must be restricted to 20 bytes
+			fp = fp[:20]
+		}
+		b, err = ecdh.Decrypt(priv.PrivateKey.(*ecdh.PrivateKey), vsG, m, oid, fp)
 	case PubKeyAlgoX25519:
 		b, err = x25519.Decrypt(priv.PrivateKey.(*x25519.PrivateKey), e.ephemeralPublicX25519, e.encryptedSession)
 	case PubKeyAlgoX448:

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -910,8 +910,7 @@ func (pk *PublicKey) VerifyRevocationHashTag(sig *Signature) (err error) {
 	if err != nil {
 		return err
 	}
-	err = keyRevocationHash(pk, preparedHash)
-	if err != nil {
+	if err = keyRevocationHash(pk, preparedHash); err != nil {
 		return err
 	}
 	return VerifyHashTag(preparedHash, sig)
@@ -924,7 +923,7 @@ func (pk *PublicKey) VerifyRevocationSignature(sig *Signature) (err error) {
 	if err != nil {
 		return err
 	}
-	if keyRevocationHash(pk, preparedHash); err != nil {
+	if err = keyRevocationHash(pk, preparedHash); err != nil {
 		return err
 	}
 	return pk.VerifySignature(preparedHash, sig)

--- a/openpgp/v2/read_test.go
+++ b/openpgp/v2/read_test.go
@@ -775,11 +775,7 @@ func TestSymmetricAeadEaxOpenPGPJsMessage(t *testing.T) {
 	}
 
 	// Decrypt with key
-	var edp packet.EncryptedDataPacket
-	if err != nil {
-		t.Fatal(err)
-	}
-	edp = p.(*packet.AEADEncrypted)
+	edp := p.(*packet.AEADEncrypted)
 	rc, err := edp.Decrypt(packet.CipherFunction(0), key)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
ECDH truncated the fingerprint to 20 bytes for version 6 crypto-refresh keys. This MR ensures that the full fingerprint is used as mandated by the [OpenPGP crypto-refresh](https://datatracker.ietf.org/doc/draft-ietf-openpgp-crypto-refresh/). Further, it resolves the complaints by the linter.