### PR TITLE
Put support for reading v5 packets behind a feature flag

### DIFF
--- a/openpgp/keys_v5_test.go
+++ b/openpgp/keys_v5_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 var foreignKeys = []string{
@@ -11,6 +13,9 @@ var foreignKeys = []string{
 }
 
 func TestReadPrivateForeignV5Key(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	for _, str := range foreignKeys {
 		kring, err := ReadArmoredKeyRing(strings.NewReader(str))
 		if err != nil {
@@ -21,6 +26,9 @@ func TestReadPrivateForeignV5Key(t *testing.T) {
 }
 
 func TestReadPrivateSerializeForeignV5Key(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	for _, str := range foreignKeys {
 		el, err := ReadArmoredKeyRing(strings.NewReader(str))
 		if err != nil {

--- a/openpgp/packet/aead_encrypted.go
+++ b/openpgp/packet/aead_encrypted.go
@@ -23,6 +23,9 @@ type AEADEncrypted struct {
 const aeadEncryptedVersion = 1
 
 func (ae *AEADEncrypted) parse(buf io.Reader) error {
+	if V5Disabled {
+		return errors.UnsupportedError("support for parsing v5 entities is disabled; change `config.V5Disabled` if needed")
+	}
 	headerData := make([]byte, 4)
 	if n, err := io.ReadFull(buf, headerData); n < 4 {
 		return errors.AEADError("could not read aead header:" + err.Error())

--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -21,6 +21,9 @@ var maxChunkSizeExp = 62
 const maxPlaintextLength = 1 << 18
 
 func TestAeadRFCParse(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	for _, sample := range samplesAeadEncryptedDataPacket {
 		key, _ := hex.DecodeString(sample.cek)
 		packetBytes, _ := hex.DecodeString(sample.full)
@@ -55,6 +58,9 @@ func TestAeadRFCParse(t *testing.T) {
 // authentication tags: One for the empty chunk, and the final auth. tag. This
 // test also checks if it cannot decrypt a corrupt stream of empty plaintext.
 func TestAeadEmptyStream(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	key := randomKey(16)
 	config := randomConfig()
 	raw, _, err := randomStream(key, 0, config)
@@ -112,6 +118,9 @@ func TestAeadEmptyStream(t *testing.T) {
 
 // Tests if encrypt/decrypt functions are callable and correct with a nil config
 func TestAeadNilConfigStream(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	// Sample key
 	key := randomKey(16)
 	randomLength := mathrand.Intn(maxPlaintextLength) + 1
@@ -150,6 +159,9 @@ func TestAeadNilConfigStream(t *testing.T) {
 
 // Encrypts and decrypts a random stream, checking correctness and integrity
 func TestAeadStreamRandomizeSlow(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	key := randomKey(16)
 	config := randomConfig()
 	randomLength := mathrand.Intn(maxPlaintextLength) + 1
@@ -190,6 +202,9 @@ func TestAeadStreamRandomizeSlow(t *testing.T) {
 
 // Encrypts a random stream, corrupt some bytes, and check if it fails
 func TestAeadCorruptStreamRandomizeSlow(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	key := randomKey(16)
 	config := randomConfig()
 	randomLength := mathrand.Intn(maxPlaintextLength) + 1
@@ -233,6 +248,9 @@ func TestAeadCorruptStreamRandomizeSlow(t *testing.T) {
 
 // Encrypts a random stream, truncate the end, and check if it fails
 func TestAeadTruncatedStreamRandomizeSlow(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	key := randomKey(16)
 	config := randomConfig()
 	randomLength := mathrand.Intn(maxPlaintextLength)
@@ -278,6 +296,9 @@ func TestAeadTruncatedStreamRandomizeSlow(t *testing.T) {
 
 // Encrypts a random stream, truncate the end, and check if it fails
 func TestAeadUnclosedStreamRandomizeSlow(t *testing.T) {
+	if V5Disabled {
+		t.Skip()
+	}
 	key := randomKey(16)
 	config := randomConfig()
 	ptLen := mathrand.Intn(maxPlaintextLength)

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -29,6 +29,15 @@ var (
 	}
 )
 
+// A global feature flag to indicate v5 support.
+// Can be set via a build tag go test -tags v5.
+// If the build tag is missing config_build.go will set it to true.
+//
+// Disables parsing of v5 keys, v5 signatures and AEAD-encrypted data packets.
+// These are non-standard entities, which in the crypto-refresh have been superseded
+// by v6 keys, v6 signatures and SEIPDv2 encrypted data, respectively.
+var V5Disabled = false
+
 // Config collects a number of parameters along with sensible defaults.
 // A nil *Config is valid and results in all default values.
 type Config struct {

--- a/openpgp/packet/config_build.go
+++ b/openpgp/packet/config_build.go
@@ -1,0 +1,7 @@
+//go:build !v5
+
+package packet
+
+func init() {
+	V5Disabled = true
+}

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -202,6 +202,10 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 	v5 := pk.PublicKey.Version == 5
 	v6 := pk.PublicKey.Version == 6
 
+	if V5Disabled && v5 {
+		return errors.UnsupportedError("support for parsing v5 entities is disabled; change `config.V5Disabled` if needed")
+	}
+
 	var buf [1]byte
 	_, err = readFull(r, buf[:])
 	if err != nil {

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -236,11 +236,16 @@ func (pk *PublicKey) parse(r io.Reader) (err error) {
 	if err != nil {
 		return
 	}
-	if buf[0] != 4 && buf[0] != 5 && buf[0] != 6 {
+
+	pk.Version = int(buf[0])
+	if pk.Version != 4 && pk.Version != 5 && pk.Version != 6 {
 		return errors.UnsupportedError("public key version " + strconv.Itoa(int(buf[0])))
 	}
 
-	pk.Version = int(buf[0])
+	if V5Disabled && pk.Version == 5 {
+		return errors.UnsupportedError("support for parsing v5 entities is disabled; change `config.V5Disabled` if needed")
+	}
+
 	if pk.Version >= 5 {
 		// Read the four-octet scalar octet count
 		// The count is not used in this implementation

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -149,11 +149,16 @@ func (sig *Signature) parse(r io.Reader) (err error) {
 	if err != nil {
 		return
 	}
-	if buf[0] != 4 && buf[0] != 5 && buf[0] != 6 {
+	sig.Version = int(buf[0])
+	if sig.Version != 4 && sig.Version != 5 && sig.Version != 6 {
 		err = errors.UnsupportedError("signature packet version " + strconv.Itoa(int(buf[0])))
 		return
 	}
-	sig.Version = int(buf[0])
+
+	if V5Disabled && sig.Version == 5 {
+		return errors.UnsupportedError("support for parsing v5 entities is disabled; change `config.V5Disabled` if needed")
+	}
+
 	if sig.Version == 6 {
 		_, err = readFull(r, buf[:7])
 	} else {

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -45,6 +45,10 @@ func (ske *SymmetricKeyEncrypted) parse(r io.Reader) error {
 		return errors.UnsupportedError("unknown SymmetricKeyEncrypted version")
 	}
 
+	if V5Disabled && ske.Version == 5 {
+		return errors.UnsupportedError("Support for parsing v5 entities is disabled; change `config.V5Disabled` if needed")
+	}
+
 	if ske.Version > 5 {
 		// Scalar octet count
 		if _, err := readFull(r, buf[:]); err != nil {

--- a/openpgp/packet/symmetric_key_encrypted_data_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_data_test.go
@@ -9,7 +9,12 @@ type packetSequence struct {
 	contents string
 }
 
-var keyAndIpePackets = []*packetSequence{symEncTestv6, aeadEaxRFC, aeadOcbRFC}
+func keyAndIpePackets() []*packetSequence {
+	if V5Disabled {
+		return []*packetSequence{symEncTestv6}
+	}
+	return []*packetSequence{symEncTestv6, aeadEaxRFC, aeadOcbRFC}
+}
 
 // https://www.ietf.org/archive/id/draft-koch-openpgp-2015-rfc4880bis-00.html#name-complete-aead-eax-encrypted-
 var aeadEaxRFC = &packetSequence{

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -19,7 +19,7 @@ const maxPassLen = 64
 
 // Tests against RFC vectors
 func TestDecryptSymmetricKeyAndEncryptedDataPacket(t *testing.T) {
-	for _, testCase := range keyAndIpePackets {
+	for _, testCase := range keyAndIpePackets() {
 		// Key
 		buf := readerFromHex(testCase.packets)
 		packet, err := Read(buf)

--- a/openpgp/read_test.go
+++ b/openpgp/read_test.go
@@ -673,6 +673,9 @@ func TestSymmetricDecryptionArgon2(t *testing.T) {
 }
 
 func TestAsymmestricAeadOcbOpenPGPjsCompressedMessage(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	// Read key from file
 	armored, err := os.Open("test_data/aead-ocb-asym-key.asc")
 	if err != nil {
@@ -719,6 +722,9 @@ func TestAsymmestricAeadOcbOpenPGPjsCompressedMessage(t *testing.T) {
 }
 
 func TestSymmetricAeadEaxOpenPGPJsMessage(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	key := []byte{79, 41, 206, 112, 224, 133, 140, 223, 27, 61, 227, 57, 114,
 		118, 64, 60, 177, 26, 42, 174, 151, 5, 186, 74, 226, 97, 214, 63, 114, 77,
 		215, 121}
@@ -890,6 +896,9 @@ func TestMessageWithoutMdc(t *testing.T) {
 }
 
 func TestReadV5Messages(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	key, err := ReadArmoredKeyRing(strings.NewReader(keyv5Test))
 	if err != nil {
 		t.Error(err)

--- a/openpgp/v2/keys_v5_test.go
+++ b/openpgp/v2/keys_v5_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
 var foreignKeys = []string{
@@ -11,6 +13,9 @@ var foreignKeys = []string{
 }
 
 func TestReadPrivateForeignV5Key(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	for _, str := range foreignKeys {
 		kring, err := ReadArmoredKeyRing(strings.NewReader(str))
 		if err != nil {
@@ -21,6 +26,9 @@ func TestReadPrivateForeignV5Key(t *testing.T) {
 }
 
 func TestReadPrivateSerializeForeignV5Key(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	for _, str := range foreignKeys {
 		el, err := ReadArmoredKeyRing(strings.NewReader(str))
 		if err != nil {

--- a/openpgp/v2/read_test.go
+++ b/openpgp/v2/read_test.go
@@ -704,6 +704,9 @@ func TestSymmetricDecryptionArgon2(t *testing.T) {
 }
 
 func TestAsymmestricAeadOcbOpenPGPjsCompressedMessage(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	// Read key from file
 	armored, err := os.Open("../test_data/aead-ocb-asym-key.asc")
 	if err != nil {
@@ -750,6 +753,9 @@ func TestAsymmestricAeadOcbOpenPGPjsCompressedMessage(t *testing.T) {
 }
 
 func TestSymmetricAeadEaxOpenPGPJsMessage(t *testing.T) {
+	if packet.V5Disabled {
+		t.Skip()
+	}
 	key := []byte{79, 41, 206, 112, 224, 133, 140, 223, 27, 61, 227, 57, 114,
 		118, 64, 60, 177, 26, 42, 174, 151, 5, 186, 74, 226, 97, 214, 63, 114, 77,
 		215, 121}


### PR DESCRIPTION
Disable parsing of v5 keys, v5 signatures and AEAD-encrypted data packets by default.  Enabling v5  requires now turning on the corresponding global flag via a build tag or changing the variable.
The affected entities are non-standard, and in the crypto-refresh RFC they have been superseded by v6 keys, v6 signatures and SEIPDv2 encrypted data, respectively.

https://github.com/openpgpjs/openpgpjs/pull/1774