### PR TITLE
Restrict S2K types

### DIFF
--- a/openpgp/keys_test.go
+++ b/openpgp/keys_test.go
@@ -1497,6 +1497,9 @@ func TestEncryptAndDecryptPrivateKeys(t *testing.T) {
 					S2KMode: mode,
 				},
 			}
+			if mode == s2k.Argon2S2K {
+				config.AEADConfig = &packet.AEADConfig{}
+			}
 			err = entity.EncryptPrivateKeys(passphrase, config)
 			if err != nil {
 				t.Fatal(err)

--- a/openpgp/packet/private_key_test.go
+++ b/openpgp/packet/private_key_test.go
@@ -144,6 +144,9 @@ func TestExternalPrivateKeyEncryptDecryptS2KModes(t *testing.T) {
 	sk2KeyTypes := []S2KType{S2KAEAD, S2KSHA1}
 	for _, s2kMode := range sk2Modes {
 		for _, sk2KeyType := range sk2KeyTypes {
+			if s2kMode == s2k.Argon2S2K && sk2KeyType == S2KSHA1 {
+				continue
+			}
 			t.Run(fmt.Sprintf("s2kMode:%d-s2kType:%d", s2kMode, sk2KeyType), func(t *testing.T) {
 				var configAEAD *AEADConfig
 				if sk2KeyType == S2KAEAD {

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -300,6 +300,10 @@ func ParseIntoParams(r io.Reader) (params *Params, err error) {
 	return nil, errors.UnsupportedError("S2K function")
 }
 
+func (params *Params) Mode() Mode {
+	return params.mode
+}
+
 func (params *Params) Dummy() bool {
 	return params != nil && params.mode == GnuS2K
 }

--- a/openpgp/v2/keys_test.go
+++ b/openpgp/v2/keys_test.go
@@ -1475,6 +1475,9 @@ func TestEncryptAndDecryptPrivateKeys(t *testing.T) {
 					S2KMode: mode,
 				},
 			}
+			if mode == s2k.Argon2S2K {
+				config.AEADConfig = &packet.AEADConfig{}
+			}
 			err = entity.EncryptPrivateKeys(passphrase, config)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
RFC9580 says that:

    Argon2 is only used with AEAD (S2K usage octet 253).  An
    implementation MUST NOT create and MUST reject as malformed any
    secret key packet where the S2K usage octet is not AEAD (253) and
    the S2K specifier type is Argon2.

Therefore, we disallow reading and writing Argon2 keys without AEAD.

And:

    [The Simple and Salted S2K methods] are used only for reading in
    backwards compatibility mode.
    
So, we disallow encrypting keys using those methods.

Since V6 keys don't need backwards compatibility, we also disallow reading Simple S2K there. We still allow reading Salted S2K since the spec says it may be used "when [the password] is high entropy".