### PR TITLE
Allow empty Key Flags subpackets

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -518,11 +518,10 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		}
 	case keyFlagsSubpacket:
 		// Key flags, section 5.2.3.21
+		sig.FlagsValid = true
 		if len(subpacket) == 0 {
-			err = errors.StructuralError("empty key flags subpacket")
 			return
 		}
-		sig.FlagsValid = true
 		if subpacket[0]&KeyFlagCertify != 0 {
 			sig.FlagCertify = true
 		}


### PR DESCRIPTION
Allow parsing empty Key Flags subpackets.

This is allowed by the spec, which says:

> This subpacket contains a list of binary flags that hold information about a key. It is a string of octets, and an implementation MUST NOT assume a fixed size. This is so it can grow over time. If a list is shorter than an implementation expects, the unstated flags are considered to be zero.

And it can be useful to explicitly say that a primary key is not allowed to be used for any purpose (except certifying subkeys), for example.