### PR TITLE
Accept both encryption key flags for encryption/decryption

### DIFF
--- a/.github/workflows/interop-test-suite.yml
+++ b/.github/workflows/interop-test-suite.yml
@@ -83,7 +83,7 @@ jobs:
     name: Run interoperability test suite
     runs-on: ubuntu-latest
     container: 
-      image: ghcr.io/protonmail/openpgp-interop-test-docker:v.1.1.3
+      image: ghcr.io/protonmail/openpgp-interop-test-docker:v1.1.9
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}

--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -782,5 +782,5 @@ func isValidCertificationKey(signature *packet.Signature, algo packet.PublicKeyA
 func isValidEncryptionKey(signature *packet.Signature, algo packet.PublicKeyAlgorithm) bool {
 	return algo.CanEncrypt() &&
 		signature.FlagsValid &&
-		signature.FlagEncryptCommunications
+		(signature.FlagEncryptCommunications || signature.FlagEncryptStorage)
 }


### PR DESCRIPTION
This pull request enables encryption and decryption of messages using keys that have either the communication or storage key flag set. Previously, only keys with the communication flag were considered.

Additionally, this PR updates the interoperability test suite to the latest version.