### PR TITLE
[v2] Check signature details of binding signatures

### DIFF
--- a/.github/test-suite/build_gosop.sh
+++ b/.github/test-suite/build_gosop.sh
@@ -1,5 +1,5 @@
 cd gosop
 echo "replace github.com/ProtonMail/go-crypto => ../go-crypto" >> go.mod
 go get github.com/ProtonMail/go-crypto
-go get github.com/ProtonMail/gopenpgp/v3/crypto@80762a9ce60ba09d8a0d4f7b2a9a9665e7716351 
+go get github.com/ProtonMail/gopenpgp/v3/crypto@db2db2c2cd366696183a2d3cf6fea63eb679e54c 
 go build .

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -19,6 +19,10 @@ var (
 		PubKeyAlgoElGamal: true,
 		PubKeyAlgoDSA:     true,
 	}
+	defaultRejectHashAlgorithms = map[crypto.Hash]bool{
+		crypto.MD5:       true,
+		crypto.RIPEMD160: true,
+	}
 	defaultRejectMessageHashAlgorithms = map[crypto.Hash]bool{
 		crypto.SHA1:      true,
 		crypto.MD5:       true,
@@ -104,6 +108,7 @@ type Config struct {
 	MinRSABits uint16
 	// Reject insecure algorithms, only works with v2 api
 	RejectPublicKeyAlgorithms   map[PublicKeyAlgorithm]bool
+	RejectHashAlgorithms        map[crypto.Hash]bool
 	RejectMessageHashAlgorithms map[crypto.Hash]bool
 	RejectCurves                map[Curve]bool
 	// "The validity period of the key.  This is the number of seconds after
@@ -337,6 +342,17 @@ func (c *Config) RejectPublicKeyAlgorithm(alg PublicKeyAlgorithm) bool {
 		rejectedAlgorithms = c.RejectPublicKeyAlgorithms
 	}
 	return rejectedAlgorithms[alg]
+}
+
+func (c *Config) RejectHashAlgorithm(hash crypto.Hash) bool {
+	var rejectedAlgorithms map[crypto.Hash]bool
+	if c == nil || c.RejectHashAlgorithms == nil {
+		// Default
+		rejectedAlgorithms = defaultRejectHashAlgorithms
+	} else {
+		rejectedAlgorithms = c.RejectHashAlgorithms
+	}
+	return rejectedAlgorithms[hash]
 }
 
 func (c *Config) RejectMessageHashAlgorithm(hash crypto.Hash) bool {

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -410,7 +410,7 @@ func (scr *signatureCheckReader) Read(buf []byte) (int, error) {
 					key := scr.md.SignedBy
 					signatureError := key.PublicKey.VerifySignature(scr.h, sig)
 					if signatureError == nil {
-						signatureError = checkSignatureDetails(key, sig, scr.config)
+						signatureError = checkMessageSignatureDetails(key, sig, scr.config)
 					}
 					scr.md.Signature = sig
 					scr.md.SignatureError = signatureError
@@ -546,7 +546,7 @@ func verifyDetachedSignature(keyring KeyRing, signed, signature io.Reader, expec
 	for _, key := range keys {
 		err = key.PublicKey.VerifySignature(h, sig)
 		if err == nil {
-			return sig, key.Entity, checkSignatureDetails(&key, sig, config)
+			return sig, key.Entity, checkMessageSignatureDetails(&key, sig, config)
 		}
 	}
 
@@ -564,7 +564,7 @@ func CheckArmoredDetachedSignature(keyring KeyRing, signed, signature io.Reader,
 	return CheckDetachedSignature(keyring, signed, body, config)
 }
 
-// checkSignatureDetails returns an error if:
+// checkMessageSignatureDetails returns an error if:
 //   - The signature (or one of the binding signatures mentioned below)
 //     has a unknown critical notation data subpacket
 //   - The primary key of the signing entity is revoked
@@ -582,7 +582,7 @@ func CheckArmoredDetachedSignature(keyring KeyRing, signed, signature io.Reader,
 // NOTE: The order of these checks is important, as the caller may choose to
 // ignore ErrSignatureExpired or ErrKeyExpired errors, but should never
 // ignore any other errors.
-func checkSignatureDetails(key *Key, signature *packet.Signature, config *packet.Config) error {
+func checkMessageSignatureDetails(key *Key, signature *packet.Signature, config *packet.Config) error {
 	now := config.Now()
 	primarySelfSignature, primaryIdentity := key.Entity.PrimarySelfSignature()
 	signedBySubKey := key.PublicKey != key.Entity.PrimaryKey

--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -698,8 +698,7 @@ func (e *Entity) LatestValidDirectSignature(date time.Time, config *packet.Confi
 // algorithm preferences, and so on.
 func (e *Entity) PrimarySelfSignature(date time.Time, config *packet.Config) (primarySig *packet.Signature, err error) {
 	if e.PrimaryKey.Version == 6 {
-		primarySig, err = e.LatestValidDirectSignature(date, config)
-		return
+		return e.LatestValidDirectSignature(date, config)
 	}
 	primarySig, _ = e.PrimaryIdentity(date, config)
 	if primarySig == nil {

--- a/openpgp/v2/keys_v6_test.go
+++ b/openpgp/v2/keys_v6_test.go
@@ -191,7 +191,7 @@ func TestNewEntityWithDefaultHashV6(t *testing.T) {
 			continue
 		}
 		var zeroTime time.Time
-		selfSig, err := entity.PrimarySelfSignature(zeroTime)
+		selfSig, err := entity.PrimarySelfSignature(zeroTime, c)
 		if err != nil {
 			t.Fatal("self-signature should be found")
 		}
@@ -212,7 +212,7 @@ func TestKeyGenerationHighSecurityLevel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	selfSig, err := entity.PrimarySelfSignature(time.Time{})
+	selfSig, err := entity.PrimarySelfSignature(time.Time{}, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -796,8 +796,7 @@ func checkMessageSignatureDetails(verifiedKey *Key, signature *packet.Signature,
 		} else {
 			time = signature.CreationTime
 		}
-		err := checkSignatureDetails(pk, sig, time, config)
-		if err != nil {
+		if err := checkSignatureDetails(pk, sig, time, config); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/openpgp/v2/read.go
+++ b/openpgp/v2/read.go
@@ -147,7 +147,7 @@ ParsePackets:
 				unverifiedEntities := keyring.EntitiesById(p.KeyId)
 				for _, unverifiedEntity := range unverifiedEntities {
 					// Do not check key expiration to allow decryption of old messages
-					keys := unverifiedEntity.DecryptionKeys(p.KeyId, time.Time{})
+					keys := unverifiedEntity.DecryptionKeys(p.KeyId, time.Time{}, config)
 					for _, key := range keys {
 						pubKeys = append(pubKeys, keyEnvelopePair{key, p})
 					}
@@ -574,7 +574,7 @@ func (scr *signatureCheckReader) Read(buf []byte) (int, error) {
 						}
 						signatureError := key.PublicKey.VerifySignature(candidate.Hash, sig)
 						if signatureError == nil {
-							signatureError = checkSignatureDetails(&key, sig, scr.config)
+							signatureError = checkMessageSignatureDetails(&key, sig, scr.config)
 						}
 						if !scr.md.IsSymmetricallyEncrypted && len(sig.IntendedRecipients) > 0 && scr.md.CheckRecipients && signatureError == nil {
 							if !scr.md.IsEncrypted {
@@ -740,43 +740,76 @@ func verifyDetachedSignatureReader(keyring KeyRing, signed, signature io.Reader,
 }
 
 // checkSignatureDetails verifies the metadata of the signature.
-// Checks the following:
-// - Hash function should not be invalid.
+// It checks the following:
+// - Hash function should not be invalid according to
+//   config.RejectHashAlgorithms.
 // - Verification key must be older than the signature creation time.
 // - Check signature notations.
-// - Signature is not expired.
-func checkSignatureDetails(verifiedKey *Key, signature *packet.Signature, config *packet.Config) error {
-	var collectedErrors []error
-	now := config.Now()
+// - Signature is not expired (unless a zero time is passed to
+//   explicitly ignore expiration).
+func checkSignatureDetails(pk *packet.PublicKey, signature *packet.Signature, now time.Time, config *packet.Config) error {
+	if config.RejectHashAlgorithm(signature.Hash) {
+		return errors.SignatureError("insecure hash algorithm: " + signature.Hash.String())
+	}
 
+	if pk.CreationTime.Unix() > signature.CreationTime.Unix() {
+		return errors.ErrSignatureOlderThanKey
+	}
+
+	for _, notation := range signature.Notations {
+		if notation.IsCritical && !config.KnownNotation(notation.Name) {
+			return errors.SignatureError("unknown critical notation: " + notation.Name)
+		}
+	}
+
+	if !now.IsZero() && signature.SigExpired(now) {
+		return errors.ErrSignatureExpired
+	}
+	return nil
+}
+
+// checkMessageSignatureDetails verifies the metadata of the signature.
+// It checks the criteria of checkSignatureDetails for the message
+// signature and all relevant binding signatures.
+// In addition, the message signature hash algorithm is checked against
+// config.RejectMessageHashAlgorithms.
+func checkMessageSignatureDetails(verifiedKey *Key, signature *packet.Signature, config *packet.Config) error {
 	if config.RejectMessageHashAlgorithm(signature.Hash) {
 		return errors.SignatureError("insecure message hash algorithm: " + signature.Hash.String())
 	}
 
-	if verifiedKey.PublicKey.CreationTime.Unix() > signature.CreationTime.Unix() {
-		collectedErrors = append(collectedErrors, errors.ErrSignatureOlderThanKey)
-	}
-
 	sigsToCheck := []*packet.Signature{signature, verifiedKey.PrimarySelfSignature}
-
 	if !verifiedKey.IsPrimary() {
 		sigsToCheck = append(sigsToCheck, verifiedKey.SelfSignature, verifiedKey.SelfSignature.EmbeddedSignature)
 	}
+	var errs []error
 	for _, sig := range sigsToCheck {
-		for _, notation := range sig.Notations {
-			if notation.IsCritical && !config.KnownNotation(notation.Name) {
-				return errors.SignatureError("unknown critical notation: " + notation.Name)
-			}
+		var pk *packet.PublicKey
+		if sig == verifiedKey.PrimarySelfSignature || sig == verifiedKey.SelfSignature {
+			pk = verifiedKey.Entity.PrimaryKey
+		} else {
+			pk = verifiedKey.PublicKey
+		}
+		var time time.Time
+		if sig == signature {
+			time = config.Now()
+		} else {
+			time = signature.CreationTime
+		}
+		err := checkSignatureDetails(pk, sig, time, config)
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	if signature.SigExpired(now) {
-		return errors.ErrSignatureExpired
+	// Return errors.ErrSignatureExpired last as gopenpgp might ignore it.
+	for _, err := range errs {
+		if err != errors.ErrSignatureExpired {
+			return err
+		}
 	}
-
-	if len(collectedErrors) > 0 {
-		// TODO: Is there a better priority for errors?
-		return collectedErrors[len(collectedErrors)-1]
+	if len(errs) != 0 {
+		return errs[0]
 	}
 	return nil
 }

--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -153,7 +153,7 @@ func detachSignWithWriter(w io.Writer, signers []*Entity, sigType packet.Signatu
 			hashToHashId(crypto.SHA3_512),
 		}
 		defaultHashes := candidateHashes[0:1]
-		primarySelfSignature, _ := signer.PrimarySelfSignature(config.Now())
+		primarySelfSignature, _ := signer.PrimarySelfSignature(config.Now(), config)
 		if primarySelfSignature == nil {
 			return nil, errors.StructuralError("signed entity has no valid self-signature")
 		}
@@ -310,7 +310,7 @@ func symmetricallyEncrypt(passphrase []byte, dataWriter io.Writer, params *Encry
 				hashToHashId(crypto.SHA3_512),
 			}
 			defaultHashes := candidateHashes[0:1]
-			primarySelfSignature, _ := signer.PrimarySelfSignature(params.Config.Now())
+			primarySelfSignature, _ := signer.PrimarySelfSignature(params.Config.Now(), params.Config)
 			if primarySelfSignature == nil {
 				return nil, errors.StructuralError("signed entity has no self-signature")
 			}
@@ -617,7 +617,7 @@ func encrypt(
 			return nil, errors.InvalidArgumentError("cannot encrypt a message to key id " + strconv.FormatUint(to[i].PrimaryKey.KeyId, 16) + " because it has no valid encryption keys")
 		}
 
-		primarySelfSignature, _ := recipient.PrimarySelfSignature(timeForEncryptionKey)
+		primarySelfSignature, _ := recipient.PrimarySelfSignature(timeForEncryptionKey, config)
 		if primarySelfSignature == nil {
 			return nil, errors.StructuralError("entity without a self-signature")
 		}
@@ -772,7 +772,7 @@ func SignWithParams(output io.Writer, signers []*Entity, params *SignParams) (in
 			hashToHashId(crypto.SHA3_512),
 		}
 		defaultHashes := candidateHashes[0:1]
-		primarySelfSignature, _ := signer.PrimarySelfSignature(params.Config.Now())
+		primarySelfSignature, _ := signer.PrimarySelfSignature(params.Config.Now(), params.Config)
 		if primarySelfSignature == nil {
 			return nil, errors.StructuralError("signed entity has no self-signature")
 		}


### PR DESCRIPTION
Check the hash algorithm, creation time, signature notations, and signature expiry (when relevant) of binding signatures when using keys.

To be able to check that all critical signature notations are known, and the hash algorithm used is valid, we add `config` parameters to all functions on the path to verifying key binding signatures in v2.

By default, we reject binding signatures using MD5 and RIPEMD-160, but this can be modified by setting the new `config.RejectHashAlgorithms` property. In the future, we should also reject binding signatures using SHA-1, but this would be a larger breaking change.