### PR TITLE
Allow Salted S2K for high-entropy passphrases

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -668,7 +668,8 @@ func (pk *PrivateKey) encrypt(key []byte, params *s2k.Params, s2kType S2KType, c
 	if params.Mode() == s2k.Argon2S2K && s2kType != S2KAEAD {
 		return errors.InvalidArgumentError("using Argon2 S2K without AEAD is not allowed")
 	}
-	if params.Mode() != s2k.Argon2S2K && params.Mode() != s2k.IteratedSaltedS2K {
+	if params.Mode() != s2k.Argon2S2K && params.Mode() != s2k.IteratedSaltedS2K &&
+		params.Mode() != s2k.SaltedS2K { // only allowed for high-entropy passphrases
 		return errors.InvalidArgumentError("insecure S2K mode")
 	}
 


### PR DESCRIPTION
Partially reverts #213 by allowing Salted S2K for high-entropy passphrases, as already enforced by https://github.com/ProtonMail/crypto/blob/3df78a3ea124d4f5ed9ec02d14e78731282dc15a/openpgp/s2k/s2k.go#L195.