### PR TITLE
ci: Fix interoperability test suite for v1 API

### DIFF
--- a/.github/test-suite/build_gosop_v1.sh
+++ b/.github/test-suite/build_gosop_v1.sh
@@ -1,5 +1,5 @@
 cd gosop
 echo "replace github.com/ProtonMail/go-crypto => ../go-crypto" >> go.mod
 go get github.com/ProtonMail/go-crypto
-go get github.com/ProtonMail/gopenpgp/v2/crypto@latest
+go get github.com/ProtonMail/gopenpgp/v2/crypto@v2.8.0-alpha.1
 go build .

--- a/.github/workflows/interop-test-suite.yml
+++ b/.github/workflows/interop-test-suite.yml
@@ -52,6 +52,7 @@ jobs:
         uses: ./.github/actions/build-gosop
         with: 
           go-crypto-ref: main
+          branch-gosop: gosop-gopenpgp-v2
           binary-location: ./gosop-main-v1
       # Upload as artifact
       - name: Upload gosop-main artifact


### PR DESCRIPTION
- Use gosop with GopenPGP v2 for v1 API
- Use specific GopenPGP v2 version instead of latest.