### PR TITLE
Fix ECDH using v6 keys

### DIFF
--- a/openpgp/ecdh/ecdh.go
+++ b/openpgp/ecdh/ecdh.go
@@ -166,9 +166,6 @@ func buildKey(pub *PublicKey, zb []byte, curveOID, fingerprint []byte, stripLead
 	if _, err := param.Write(fingerprint[:]); err != nil {
 		return nil, err
 	}
-	if param.Len()-len(curveOID) != 45 {
-		return nil, errors.New("ecdh: malformed KDF Param")
-	}
 
 	// MB = Hash ( 00 || 00 || 00 || 01 || ZB || Param );
 	h := pub.KDF.Hash.New()


### PR DESCRIPTION
When using ECDH with v6 keys, the fingerprint length is not 20 bytes, so the KDF param is not 45 bytes.

(Note that this was already fixed in the Proton branch because this check was removed in #141 for unrelated reasons.)