### PR TITLE
Improve AEAD handling

### DIFF
--- a/openpgp/packet/encrypted_key.go
+++ b/openpgp/packet/encrypted_key.go
@@ -321,7 +321,8 @@ func (e *EncryptedKey) Serialize(w io.Writer) error {
 
 // SerializeEncryptedKeyAEAD serializes an encrypted key packet to w that contains
 // key, encrypted to pub.
-// If aeadSupported is set, PKESK v6 is used else v4.
+// If aeadSupported is set, PKESK v6 is used, otherwise v3.
+// Note: aeadSupported MUST match the value passed to SerializeSymmetricallyEncrypted.
 // If config is nil, sensible defaults will be used.
 func SerializeEncryptedKeyAEAD(w io.Writer, pub *PublicKey, cipherFunc CipherFunction, aeadSupported bool, key []byte, config *Config) error {
 	return SerializeEncryptedKeyAEADwithHiddenOption(w, pub, cipherFunc, aeadSupported, key, false, config)
@@ -330,7 +331,8 @@ func SerializeEncryptedKeyAEAD(w io.Writer, pub *PublicKey, cipherFunc CipherFun
 // SerializeEncryptedKeyAEADwithHiddenOption serializes an encrypted key packet to w that contains
 // key, encrypted to pub.
 // Offers the hidden flag option to indicated if the PKESK packet should include a wildcard KeyID.
-// If aeadSupported is set, PKESK v6 is used else v4.
+// If aeadSupported is set, PKESK v6 is used, otherwise v3.
+// Note: aeadSupported MUST match the value passed to SerializeSymmetricallyEncrypted.
 // If config is nil, sensible defaults will be used.
 func SerializeEncryptedKeyAEADwithHiddenOption(w io.Writer, pub *PublicKey, cipherFunc CipherFunction, aeadSupported bool, key []byte, hidden bool, config *Config) error {
 	var buf [36]byte // max possible header size is v6

--- a/openpgp/packet/encrypted_key.go
+++ b/openpgp/packet/encrypted_key.go
@@ -426,6 +426,7 @@ func SerializeEncryptedKeyAEADwithHiddenOption(w io.Writer, pub *PublicKey, ciph
 // key, encrypted to pub.
 // PKESKv6 is used if config.AEAD() is not nil.
 // If config is nil, sensible defaults will be used.
+// Deprecated: Use SerializeEncryptedKeyAEAD instead.
 func SerializeEncryptedKey(w io.Writer, pub *PublicKey, cipherFunc CipherFunction, key []byte, config *Config) error {
 	return SerializeEncryptedKeyAEAD(w, pub, cipherFunc, config.AEAD() != nil, key, config)
 }
@@ -434,6 +435,7 @@ func SerializeEncryptedKey(w io.Writer, pub *PublicKey, cipherFunc CipherFunctio
 // key, encrypted to pub. PKESKv6 is used if config.AEAD() is not nil.
 // The hidden option controls if the packet should be anonymous, i.e., omit key metadata.
 // If config is nil, sensible defaults will be used.
+// Deprecated: Use SerializeEncryptedKeyAEADwithHiddenOption instead.
 func SerializeEncryptedKeyWithHiddenOption(w io.Writer, pub *PublicKey, cipherFunc CipherFunction, key []byte, hidden bool, config *Config) error {
 	return SerializeEncryptedKeyAEADwithHiddenOption(w, pub, cipherFunc, config.AEAD() != nil, key, hidden, config)
 }

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -195,6 +195,7 @@ func SerializeSymmetricKeyEncrypted(w io.Writer, passphrase []byte, config *Conf
 // the given passphrase. The returned session key must be passed to
 // SerializeSymmetricallyEncrypted.
 // If config is nil, sensible defaults will be used.
+// Deprecated: Use SerializeSymmetricKeyEncryptedAEADReuseKey instead.
 func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, passphrase []byte, config *Config) (err error) {
 	return SerializeSymmetricKeyEncryptedAEADReuseKey(w, sessionKey, passphrase, config.AEAD() != nil, config)
 }

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -196,8 +196,17 @@ func SerializeSymmetricKeyEncrypted(w io.Writer, passphrase []byte, config *Conf
 // SerializeSymmetricallyEncrypted.
 // If config is nil, sensible defaults will be used.
 func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, passphrase []byte, config *Config) (err error) {
+	return SerializeSymmetricKeyEncryptedAEADReuseKey(w, sessionKey, passphrase, config.AEAD() != nil, config)
+}
+
+// SerializeSymmetricKeyEncryptedAEADReuseKey serializes a symmetric key packet to w.
+// The packet contains the given session key, encrypted by a key derived from
+// the given passphrase. The returned session key must be passed to
+// SerializeSymmetricallyEncrypted.
+// If config is nil, sensible defaults will be used.
+func SerializeSymmetricKeyEncryptedAEADReuseKey(w io.Writer, sessionKey []byte, passphrase []byte, aeadSupported bool, config *Config) (err error) {
 	var version int
-	if config.AEAD() != nil {
+	if aeadSupported {
 		version = 6
 	} else {
 		version = 4

--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -204,6 +204,8 @@ func SerializeSymmetricKeyEncryptedReuseKey(w io.Writer, sessionKey []byte, pass
 // The packet contains the given session key, encrypted by a key derived from
 // the given passphrase. The returned session key must be passed to
 // SerializeSymmetricallyEncrypted.
+// If aeadSupported is set, SKESK v6 is used, otherwise v4.
+// Note: aeadSupported MUST match the value passed to SerializeSymmetricallyEncrypted.
 // If config is nil, sensible defaults will be used.
 func SerializeSymmetricKeyEncryptedAEADReuseKey(w io.Writer, sessionKey []byte, passphrase []byte, aeadSupported bool, config *Config) (err error) {
 	var version int

--- a/openpgp/packet/symmetrically_encrypted.go
+++ b/openpgp/packet/symmetrically_encrypted.go
@@ -74,6 +74,10 @@ func (se *SymmetricallyEncrypted) Decrypt(c CipherFunction, key []byte) (io.Read
 // SerializeSymmetricallyEncrypted serializes a symmetrically encrypted packet
 // to w and returns a WriteCloser to which the to-be-encrypted packets can be
 // written.
+// If aeadSupported is set to true, SEIPDv2 is used with the indicated CipherSuite.
+// Otherwise, SEIPDv1 is used with the indicated CipherFunction.
+// Note: aeadSupported MUST match the value passed to SerializeEncryptedKeyAEAD
+// and/or SerializeSymmetricKeyEncryptedAEADReuseKey.
 // If config is nil, sensible defaults will be used.
 func SerializeSymmetricallyEncrypted(w io.Writer, c CipherFunction, aeadSupported bool, cipherSuite CipherSuite, key []byte, config *Config) (Contents io.WriteCloser, err error) {
 	writeCloser := noOpCloser{w}

--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -691,7 +691,7 @@ func encrypt(
 	}
 
 	for _, password := range params.Passwords {
-		if err = packet.SerializeSymmetricKeyEncryptedReuseKey(params.KeyWriter, params.SessionKey, password, params.Config); err != nil {
+		if err = packet.SerializeSymmetricKeyEncryptedAEADReuseKey(params.KeyWriter, params.SessionKey, password, aeadSupported, params.Config); err != nil {
 			return nil, err
 		}
 	}

--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -594,8 +594,8 @@ func encrypt(
 	encryptKeys := make([]Key, len(to)+len(toHidden))
 
 	config := params.Config
-	// AEAD is used only if config enables it and every key supports it
-	aeadSupported := config.AEAD() != nil
+	// AEAD is used if every key supports it
+	aeadSupported := true
 
 	var intendedRecipients []*packet.Recipient
 	// Intended Recipient Fingerprint subpacket SHOULD be used when creating a signed and encrypted message


### PR DESCRIPTION
- In the v2 API, use AEAD if all public keys support it
- Add `SerializeSymmetricKeyEncryptedAEADReuseKey`
  Allow explicitly indicating whether AEAD is supported when creating an SKESK packet, instead of looking at `config.AEAD()`, as the config is no longer reliable, and we shouldn't mix SKESKv3 and SEIPDv2, for example.
- Deprecate `SerializeEncryptedKey[WithHiddenOption]` and `SerializeSymmetricKeyEncryptedReuseKey`
  These functions don't allow explicitly indicating whether AEAD is supported and are thus prone to misuse. The `*AEAD` versions should be used instead.
- Improve documentation
  Document that the `aeadSupported` parameter passed to `SerializeEncryptedKeyAEAD[withHiddenOption]`, `SerializeSymmetricKeyEncryptedAEADReuseKey`, and `SerializeSymmetricallyEncrypted` must match.