### PR TITLE
Adapt aead preferences on key generation

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -91,13 +91,15 @@ func (t *Entity) AddUserId(name, comment, email string, config *packet.Config) e
 }
 
 func writeKeyProperties(selfSignature *packet.Signature, creationTime time.Time, keyLifetimeSecs uint32, config *packet.Config) error {
+	advertiseAead := config.AEAD() != nil
+
 	selfSignature.CreationTime = creationTime
 	selfSignature.KeyLifetimeSecs = &keyLifetimeSecs
 	selfSignature.FlagsValid = true
 	selfSignature.FlagSign = true
 	selfSignature.FlagCertify = true
 	selfSignature.SEIPDv1 = true // true by default, see 5.8 vs. 5.14
-	selfSignature.SEIPDv2 = config.AEAD() != nil
+	selfSignature.SEIPDv2 = advertiseAead
 
 	// Set the PreferredHash for the SelfSignature from the packet.Config.
 	// If it is not the must-implement algorithm from rfc4880bis, append that.
@@ -126,16 +128,18 @@ func writeKeyProperties(selfSignature *packet.Signature, creationTime time.Time,
 		selfSignature.PreferredCompression = append(selfSignature.PreferredCompression, uint8(config.Compression()))
 	}
 
-	// And for DefaultMode.
-	modes := []uint8{uint8(config.AEAD().Mode())}
-	if config.AEAD().Mode() != packet.AEADModeOCB {
-		modes = append(modes, uint8(packet.AEADModeOCB))
-	}
+	if advertiseAead {
+		// And for DefaultMode.
+		modes := []uint8{uint8(config.AEAD().Mode())}
+		if config.AEAD().Mode() != packet.AEADModeOCB {
+			modes = append(modes, uint8(packet.AEADModeOCB))
+		}
 
-	// For preferred (AES256, GCM), we'll generate (AES256, GCM), (AES256, OCB), (AES128, GCM), (AES128, OCB)
-	for _, cipher := range selfSignature.PreferredSymmetric {
-		for _, mode := range modes {
-			selfSignature.PreferredCipherSuites = append(selfSignature.PreferredCipherSuites, [2]uint8{cipher, mode})
+		// For preferred (AES256, GCM), we'll generate (AES256, GCM), (AES256, OCB), (AES128, GCM), (AES128, OCB)
+		for _, cipher := range selfSignature.PreferredSymmetric {
+			for _, mode := range modes {
+				selfSignature.PreferredCipherSuites = append(selfSignature.PreferredCipherSuites, [2]uint8{cipher, mode})
+			}
 		}
 	}
 	return nil

--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -129,7 +129,8 @@ func writeKeyProperties(selfSignature *packet.Signature, creationTime time.Time,
 	}
 
 	if advertiseAead {
-		// And for DefaultMode.
+		// Get the preferred AEAD mode from the packet.Config.
+		// If it is not the must-implement algorithm from rfc9580, append that.
 		modes := []uint8{uint8(config.AEAD().Mode())}
 		if config.AEAD().Mode() != packet.AEADModeOCB {
 			modes = append(modes, uint8(packet.AEADModeOCB))

--- a/openpgp/v2/key_generation.go
+++ b/openpgp/v2/key_generation.go
@@ -200,7 +200,8 @@ func writeKeyProperties(selfSignature *packet.Signature, selectedKeyProperties *
 	}
 
 	if advertiseAead {
-		// And for DefaultMode.
+		// Get the preferred AEAD mode from the packet.Config.
+		// If it is not the must-implement algorithm from rfc9580, append that.
 		modes := []uint8{uint8(selectedKeyProperties.aead.Mode())}
 		if selectedKeyProperties.aead.Mode() != packet.AEADModeOCB {
 			modes = append(modes, uint8(packet.AEADModeOCB))

--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -61,7 +61,8 @@ func (e *Entity) PrimaryIdentity(date time.Time, config *packet.Config) (*packet
 	var primaryIdentityCandidatesSelfSigs []*packet.Signature
 	for _, identity := range e.Identities {
 		selfSig, err := identity.Verify(date, config) // identity must be valid at date
-		if err == nil {                               // verification is successful
+		if err == nil {
+			// verification is successful
 			primaryIdentityCandidates = append(primaryIdentityCandidates, identity)
 			primaryIdentityCandidatesSelfSigs = append(primaryIdentityCandidatesSelfSigs, selfSig)
 		}

--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -61,7 +61,7 @@ func (e *Entity) PrimaryIdentity(date time.Time, config *packet.Config) (*packet
 	var primaryIdentityCandidatesSelfSigs []*packet.Signature
 	for _, identity := range e.Identities {
 		selfSig, err := identity.Verify(date, config) // identity must be valid at date
-		if err == nil {                       // verification is successful
+		if err == nil {                               // verification is successful
 			primaryIdentityCandidates = append(primaryIdentityCandidates, identity)
 			primaryIdentityCandidatesSelfSigs = append(primaryIdentityCandidatesSelfSigs, selfSig)
 		}


### PR DESCRIPTION
Advertise SEIPDv2 and AEAD modes during key generation only if AEAD configuration is enabled.