### PR TITLE
Reduce memory usage when AEAD en/decrypting large messages

### DIFF
--- a/internal/byteutil/byteutil.go
+++ b/internal/byteutil/byteutil.go
@@ -49,16 +49,16 @@ func ShiftNBytesLeft(dst, x []byte, n int) {
 	dst = append(dst, make([]byte, n/8)...)
 }
 
-// XorBytesMut assumes equal input length, replaces X with X XOR Y
+// XorBytesMut replaces X with X XOR Y. len(X) must be >= len(Y).
 func XorBytesMut(X, Y []byte) {
-	for i := 0; i < len(X); i++ {
+	for i := 0; i < len(Y); i++ {
 		X[i] ^= Y[i]
 	}
 }
 
-// XorBytes assumes equal input length, puts X XOR Y into Z
+// XorBytes puts X XOR Y into Z. len(Z) and len(X) must be >= len(Y).
 func XorBytes(Z, X, Y []byte) {
-	for i := 0; i < len(X); i++ {
+	for i := 0; i < len(Y); i++ {
 		Z[i] = X[i] ^ Y[i]
 	}
 }

--- a/openpgp/packet/aead_crypter.go
+++ b/openpgp/packet/aead_crypter.go
@@ -125,7 +125,7 @@ func (ar *aeadDecrypter) openChunk(data []byte) ([]byte, error) {
 	}
 
 	nonce := ar.computeNextNonce()
-	plainChunk, err := ar.aead.Open(nil, nonce, data, adata)
+	plainChunk, err := ar.aead.Open(data[:0:len(data)], nonce, data, adata)
 	if err != nil {
 		return nil, errors.ErrAEADTagVerification
 	}
@@ -243,7 +243,7 @@ func (aw *aeadEncrypter) sealChunk(data []byte) ([]byte, error) {
 	}
 
 	nonce := aw.computeNextNonce()
-	encrypted := aw.aead.Seal(nil, nonce, data, adata)
+	encrypted := aw.aead.Seal(data[:0:len(data)], nonce, data, adata)
 	aw.bytesProcessed += len(data)
 	if err := aw.aeadCrypter.incrementIndex(); err != nil {
 		return nil, err

--- a/openpgp/packet/aead_crypter.go
+++ b/openpgp/packet/aead_crypter.go
@@ -15,7 +15,7 @@ import (
 type aeadCrypter struct {
 	aead           cipher.AEAD
 	chunkSize      int
-	initialNonce   []byte
+	nonce          []byte
 	associatedData []byte       // Chunk-independent associated data
 	chunkIndex     []byte       // Chunk counter
 	packetTag      packetType   // SEIP packet (v2) or AEAD Encrypted Data packet
@@ -28,12 +28,12 @@ type aeadCrypter struct {
 // 5.16.1 and 5.16.2). It returns the resulting nonce.
 func (wo *aeadCrypter) computeNextNonce() (nonce []byte) {
 	if wo.packetTag == packetTypeSymmetricallyEncryptedIntegrityProtected {
-		return append(wo.initialNonce, wo.chunkIndex...)
+		return wo.nonce
 	}
 
-	nonce = make([]byte, len(wo.initialNonce))
-	copy(nonce, wo.initialNonce)
-	offset := len(wo.initialNonce) - 8
+	nonce = make([]byte, len(wo.nonce))
+	copy(nonce, wo.nonce)
+	offset := len(wo.nonce) - 8
 	for i := 0; i < 8; i++ {
 		nonce[i+offset] ^= wo.chunkIndex[i]
 	}

--- a/openpgp/packet/aead_crypter.go
+++ b/openpgp/packet/aead_crypter.go
@@ -62,8 +62,8 @@ func (wo *aeadCrypter) incrementIndex() error {
 type aeadDecrypter struct {
 	aeadCrypter           // Embedded ciphertext opener
 	reader      io.Reader // 'reader' is a partialLengthReader
+	chunkBytes  []byte
 	peekedBytes []byte    // Used to detect last chunk
-	eof         bool
 }
 
 // Read decrypts bytes and reads them into dst. It decrypts when necessary and
@@ -75,22 +75,18 @@ func (ar *aeadDecrypter) Read(dst []byte) (n int, err error) {
 		return ar.buffer.Read(dst)
 	}
 
-	// Return EOF if we've previously validated the final tag
-	if ar.eof {
-		return 0, io.EOF
-	}
-
 	// Read a chunk
 	tagLen := ar.aead.Overhead()
-	cipherChunkBuf := new(bytes.Buffer)
-	_, errRead := io.CopyN(cipherChunkBuf, ar.reader, int64(ar.chunkSize+tagLen))
-	cipherChunk := cipherChunkBuf.Bytes()
-	if errRead != nil && errRead != io.EOF {
+	copy(ar.chunkBytes, ar.peekedBytes) // Copy bytes peeked in previous chunk or in initialization
+	bytesRead, errRead := io.ReadFull(ar.reader, ar.chunkBytes[tagLen:])
+	if errRead != nil && errRead != io.EOF && errRead != io.ErrUnexpectedEOF {
 		return 0, errRead
 	}
 
-	if len(cipherChunk) > 0 {
-		decrypted, errChunk := ar.openChunk(cipherChunk)
+	if bytesRead > 0 {
+		ar.peekedBytes = ar.chunkBytes[bytesRead:bytesRead+tagLen]
+
+		decrypted, errChunk := ar.openChunk(ar.chunkBytes[:bytesRead])
 		if errChunk != nil {
 			return 0, errChunk
 		}
@@ -102,28 +98,19 @@ func (ar *aeadDecrypter) Read(dst []byte) (n int, err error) {
 		} else {
 			n = copy(dst, decrypted)
 		}
+		return
 	}
 
-	// Check final authentication tag
-	if errRead == io.EOF {
-		errChunk := ar.validateFinalTag(ar.peekedBytes)
-		if errChunk != nil {
-			return n, errChunk
-		}
-		ar.eof = true // Mark EOF for when we've returned all buffered data
-	}
-	return
+	return 0, io.EOF
 }
 
-// Close is noOp. The final authentication tag of the stream was already
-// checked in the last Read call. In the future, this function could be used to
-// wipe the reader and peeked, decrypted bytes, if necessary.
+// Close checks the final authentication tag of the stream.
+// In the future, this function could also be used to wipe the reader
+// and peeked & decrypted bytes, if necessary.
 func (ar *aeadDecrypter) Close() (err error) {
-	if !ar.eof {
-		errChunk := ar.validateFinalTag(ar.peekedBytes)
-		if errChunk != nil {
-			return errChunk
-		}
+	errChunk := ar.validateFinalTag(ar.peekedBytes)
+	if errChunk != nil {
+		return errChunk
 	}
 	return nil
 }
@@ -132,20 +119,13 @@ func (ar *aeadDecrypter) Close() (err error) {
 // the underlying plaintext and an error. It accesses peeked bytes from next
 // chunk, to identify the last chunk and decrypt/validate accordingly.
 func (ar *aeadDecrypter) openChunk(data []byte) ([]byte, error) {
-	tagLen := ar.aead.Overhead()
-	// Restore carried bytes from last call
-	chunkExtra := append(ar.peekedBytes, data...)
-	// 'chunk' contains encrypted bytes, followed by an authentication tag.
-	chunk := chunkExtra[:len(chunkExtra)-tagLen]
-	ar.peekedBytes = chunkExtra[len(chunkExtra)-tagLen:]
-
 	adata := ar.associatedData
 	if ar.aeadCrypter.packetTag == packetTypeAEADEncrypted {
 		adata = append(ar.associatedData, ar.chunkIndex...)
 	}
 
 	nonce := ar.computeNextNonce()
-	plainChunk, err := ar.aead.Open(nil, nonce, chunk, adata)
+	plainChunk, err := ar.aead.Open(nil, nonce, data, adata)
 	if err != nil {
 		return nil, errors.ErrAEADTagVerification
 	}

--- a/openpgp/packet/aead_encrypted.go
+++ b/openpgp/packet/aead_encrypted.go
@@ -76,7 +76,7 @@ func (ae *AEADEncrypted) decrypt(key []byte) (io.ReadCloser, error) {
 		aeadCrypter: aeadCrypter{
 			aead:           aead,
 			chunkSize:      chunkSize,
-			initialNonce:   ae.initialNonce,
+			nonce:          ae.initialNonce,
 			associatedData: ae.associatedData(),
 			chunkIndex:     make([]byte, 8),
 			packetTag:      packetTypeAEADEncrypted,

--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -407,6 +407,7 @@ func readDecryptedStream(rc io.ReadCloser) (got []byte, err error) {
 			}
 		}
 	}
+	err = rc.Close()
 	return got, err
 }
 

--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -454,7 +454,7 @@ func SerializeAEADEncrypted(w io.Writer, key []byte, config *Config) (io.WriteCl
 			chunkSize:      chunkSize,
 			associatedData: prefix,
 			chunkIndex:     make([]byte, 8),
-			initialNonce:   nonce,
+			nonce:          nonce,
 			packetTag:      packetTypeAEADEncrypted,
 		},
 		writer: writer,

--- a/openpgp/packet/aead_encrypted_test.go
+++ b/openpgp/packet/aead_encrypted_test.go
@@ -449,6 +449,8 @@ func SerializeAEADEncrypted(w io.Writer, key []byte, config *Config) (io.WriteCl
 	alg := aeadConf.Mode().new(blockCipher)
 
 	chunkSize := decodeAEADChunkSize(aeadConf.ChunkSizeByte())
+	tagLen := alg.Overhead()
+	chunkBytes := make([]byte, chunkSize+tagLen)
 	return &aeadEncrypter{
 		aeadCrypter: aeadCrypter{
 			aead:           alg,
@@ -458,6 +460,7 @@ func SerializeAEADEncrypted(w io.Writer, key []byte, config *Config) (io.WriteCl
 			nonce:          nonce,
 			packetTag:      packetTypeAEADEncrypted,
 		},
-		writer: writer,
+		writer:     writer,
+		chunkBytes: chunkBytes,
 	}, nil
 }

--- a/openpgp/packet/symmetrically_encrypted_aead.go
+++ b/openpgp/packet/symmetrically_encrypted_aead.go
@@ -133,16 +133,20 @@ func serializeSymmetricallyEncryptedAead(ciphertext io.WriteCloser, cipherSuite 
 
 	aead, nonce := getSymmetricallyEncryptedAeadInstance(cipherSuite.Cipher, cipherSuite.Mode, inputKey, salt, prefix)
 
+	chunkSize := decodeAEADChunkSize(chunkSizeByte)
+	tagLen := aead.Overhead()
+	chunkBytes := make([]byte, chunkSize+tagLen)
 	return &aeadEncrypter{
 		aeadCrypter: aeadCrypter{
 			aead:           aead,
-			chunkSize:      decodeAEADChunkSize(chunkSizeByte),
+			chunkSize:      chunkSize,
 			associatedData: prefix,
 			nonce:          nonce,
 			chunkIndex:     nonce[len(nonce)-8:],
 			packetTag:      packetTypeSymmetricallyEncryptedIntegrityProtected,
 		},
-		writer: ciphertext,
+		writer:     ciphertext,
+		chunkBytes: chunkBytes,
 	}, nil
 }
 


### PR DESCRIPTION
The AEAD code buffered the data to be en/decrypted at multiple points. Firstly, when decrypting, the ciphertext was buffered in order to not pre-allocate the chunk size. However, given RFC9580 caps the chunk size at 4MiB, and most (all?) OSes reuse empty pages, the overhead of allocating the the entire chunk size (256KiB by default in our implementation) is not that large. This leads to a large reduction in memory usage when decrypting large messages, at the cost of somewhat increased memory usage when decrypting small messages. For an added reduction, the ciphertext buffer can be reused for the plaintext, and also for the buffered plaintext when it's read across multiple calls to `Read()`.

Similarly, we can reduce the memory usage when encrypting large messages (though not by as much) by manually buffering the plaintext to be encrypted carefully to reserve space for the tag. That way, the plaintext buffer can be reused for the ciphertext.

Finally, fix OCB en/decryption when reusing the buffer.


Before (chunk size = 256KiB):

```
BenchmarkEncryptOpenPgpAEAD1KB-20           1000              5906 ns/op           11637 B/op         69 allocs/op
BenchmarkDecryptOpenPgpAEAD1KB-20           1000              7413 ns/op           15664 B/op         82 allocs/op
BenchmarkEncryptOpenPgpAEAD1MB-20           1000           1452205 ns/op         6853508 B/op        104 allocs/op
BenchmarkDecryptOpenPgpAEAD1MB-20           1000           2319484 ns/op        11728449 B/op        337 allocs/op
BenchmarkEncryptOpenPgpAEAD4MB-20           1000           3911609 ns/op        26908267 B/op        202 allocs/op
BenchmarkDecryptOpenPgpAEAD4MB-20           1000           6586654 ns/op        46843797 B/op       1064 allocs/op
```

After (chunk size = 256KiB):

```
BenchmarkEncryptOpenPgpAEAD1KB-20           1000             33286 ns/op          279538 B/op         62 allocs/op
BenchmarkDecryptOpenPgpAEAD1KB-20           1000             34539 ns/op          277458 B/op         65 allocs/op
BenchmarkEncryptOpenPgpAEAD1MB-20           1000           1441909 ns/op         5083626 B/op         65 allocs/op
BenchmarkDecryptOpenPgpAEAD1MB-20           1000           1361304 ns/op         5515768 B/op         92 allocs/op
BenchmarkEncryptOpenPgpAEAD4MB-20           1000           3265659 ns/op        17863129 B/op         67 allocs/op
BenchmarkDecryptOpenPgpAEAD4MB-20           1000           3672796 ns/op        21383718 B/op        110 allocs/op
```

After (chunk size = 4MiB):

```
BenchmarkEncryptOpenPgpAEAD1KB-20           1000             15371 ns/op           82896 B/op         62 allocs/op
BenchmarkDecryptOpenPgpAEAD1KB-20           1000             18963 ns/op           80848 B/op         65 allocs/op
BenchmarkEncryptOpenPgpAEAD1MB-20           1000           1257834 ns/op         4690397 B/op         67 allocs/op
BenchmarkDecryptOpenPgpAEAD1MB-20           1000           1633398 ns/op         5319211 B/op        104 allocs/op
BenchmarkEncryptOpenPgpAEAD4MB-20           1000           3122793 ns/op        18059736 B/op         69 allocs/op
BenchmarkDecryptOpenPgpAEAD4MB-20           1000           3707209 ns/op        21187301 B/op        159 allocs/op
```

After (chunk size = message size):

```
BenchmarkEncryptOpenPgpAEAD1KB-20           1000              5402 ns/op           10320 B/op         62 allocs/op
BenchmarkDecryptOpenPgpAEAD1KB-20           1000              4605 ns/op            8277 B/op         65 allocs/op
BenchmarkEncryptOpenPgpAEAD1MB-20           1000           1416058 ns/op         4690407 B/op         67 allocs/op
BenchmarkDecryptOpenPgpAEAD1MB-20           1000           1530036 ns/op         5319209 B/op        104 allocs/op
BenchmarkEncryptOpenPgpAEAD4MB-20           1000           3060694 ns/op        18059737 B/op         69 allocs/op
BenchmarkDecryptOpenPgpAEAD4MB-20           1000           3710514 ns/op        21187300 B/op        159 allocs/op
```

Because of the above results, it may be worth setting the chunk size to the message size when known (e.g. in gopenpgp).