### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/interop-test-suite.yml
+++ b/.github/workflows/interop-test-suite.yml
@@ -18,7 +18,7 @@ jobs:
           branch-gosop: gosop-gopenpgp-v2
       # Upload as artifact
       - name: Upload gosop artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-${{ github.sha }}-v1
           path: ./gosop-${{ github.sha }}-v1
@@ -37,7 +37,7 @@ jobs:
           gosop-build-path: build_gosop.sh
       # Upload as artifact
       - name: Upload gosop artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-${{ github.sha }}-v2
           path: ./gosop-${{ github.sha }}-v2
@@ -56,7 +56,7 @@ jobs:
           binary-location: ./gosop-main-v1
       # Upload as artifact
       - name: Upload gosop-main artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-main-v1
           path: ./gosop-main-v1
@@ -76,7 +76,7 @@ jobs:
           gosop-build-path: build_gosop.sh
       # Upload as artifact
       - name: Upload gosop-main artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gosop-main-v2
           path: ./gosop-main-v2
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
       # Fetch gosop from main v1
       - name: Download gosop-main-v1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-main-v1
       # Test gosop-main-v1
@@ -109,7 +109,7 @@ jobs:
         run: ./gosop-main-v1 version --extended
       # Fetch gosop from main v2
       - name: Download gosop-main-v2
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-main-v2
       # Test gosop-main-v2
@@ -119,7 +119,7 @@ jobs:
         run: ./gosop-main-v2 version --extended
       # Fetch gosop from branch v1
       - name: Download gosop-branch-v1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-${{ github.sha }}-v1
       - name: Rename gosop-branch-v1
@@ -131,7 +131,7 @@ jobs:
         run: ./gosop-branch-v1 version --extended
       # Fetch gosop from branch v2
       - name: Download gosop-branch-v2
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gosop-${{ github.sha }}-v2
       - name: Rename gosop-branch-v2
@@ -157,12 +157,12 @@ jobs:
          RESULTS_HTML: .github/test-suite/test-suite-results.html
       # Upload results
       - name: Upload test results json artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-suite-results.json
           path: .github/test-suite/test-suite-results.json
       - name: Upload test results html artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-suite-results.html
           path: .github/test-suite/test-suite-results.html
@@ -176,7 +176,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download test results json artifact
         id: download-test-results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: test-suite-results.json
       - name: Compare with baseline v1


### PR DESCRIPTION
The v3 versions [are deprecated and will stop working](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).