### PR TITLE
Check binding signature details against primary key

### DIFF
--- a/openpgp/v2/subkeys.go
+++ b/openpgp/v2/subkeys.go
@@ -187,7 +187,7 @@ func (s *Subkey) LatestValidBindingSignature(date time.Time, config *packet.Conf
 			if sig.Valid == nil {
 				err := s.Primary.PrimaryKey.VerifyKeySignature(s.PublicKey, sig.Packet)
 				if err == nil {
-					err = checkSignatureDetails(s.PublicKey, sig.Packet, date, config)
+					err = checkSignatureDetails(s.Primary.PrimaryKey, sig.Packet, date, config)
 				}
 				valid := err == nil
 				sig.Valid = &valid


### PR DESCRIPTION
Rather than checking the binding signature details against the subkey (i.e. the subject of the binding signature), check them against the primary key (i.e. the signing key).