### PR TITLE
v2 API: Improve error message for encryption key selection

### DIFF
--- a/openpgp/errors/errors.go
+++ b/openpgp/errors/errors.go
@@ -6,6 +6,7 @@
 package errors // import "github.com/ProtonMail/go-crypto/openpgp/errors"
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -177,4 +178,23 @@ type ErrMalformedMessage string
 
 func (dke ErrMalformedMessage) Error() string {
 	return "openpgp: malformed message " + string(dke)
+}
+
+// ErrEncryptionKeySelection is returned if encryption key selection fails (v2 API).
+type ErrEncryptionKeySelection struct {
+	PrimaryKeyId      string
+	PrimaryKeyErr     error
+	EncSelectionKeyId *string
+	EncSelectionErr   error
+}
+
+func (eks ErrEncryptionKeySelection) Error() string {
+	prefix := fmt.Sprintf("openpgp: key selection for primary key %s:", eks.PrimaryKeyId)
+	if eks.PrimaryKeyErr != nil {
+		return fmt.Sprintf("%s invalid primary key: %s", prefix, eks.PrimaryKeyErr)
+	}
+	if eks.EncSelectionKeyId != nil {
+		return fmt.Sprintf("%s invalid encryption key %s: %s", prefix, *eks.EncSelectionKeyId, eks.EncSelectionErr)
+	}
+	return fmt.Sprintf("%s no encryption key: %s", prefix, eks.EncSelectionErr)
 }

--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -98,27 +98,60 @@ func shouldPreferIdentity(existingId, potentialNewId *packet.Signature) bool {
 // EncryptionKey returns the best candidate Key for encrypting a message to the
 // given Entity.
 func (e *Entity) EncryptionKey(now time.Time, config *packet.Config) (Key, bool) {
+	encryptionKey, err := e.EncryptionKeyWithError(now, config)
+	return encryptionKey, err == nil
+}
+
+// EncryptionKey returns the best candidate Key for encrypting a message to the
+// given Entity.
+// Provides an error if the function fails to find an encryption key.
+func (e *Entity) EncryptionKeyWithError(now time.Time, config *packet.Config) (Key, error) {
 	// The primary key has to be valid at time now
 	primarySelfSignature, err := e.VerifyPrimaryKey(now, config)
 	if err != nil { // primary key is not valid
-		return Key{}, false
+		return Key{}, errors.ErrEncryptionKeySelection{
+			PrimaryKeyId:  e.PrimaryKey.KeyIdString(),
+			PrimaryKeyErr: err,
+		}
 	}
 
 	if checkKeyRequirements(e.PrimaryKey, config) != nil {
 		// The primary key produces weak signatures
-		return Key{}, false
+		return Key{}, errors.ErrEncryptionKeySelection{
+			PrimaryKeyId:  e.PrimaryKey.KeyIdString(),
+			PrimaryKeyErr: err,
+		}
 	}
 
 	// Iterate the keys to find the newest, unexpired one
+	var latestSelectionError *errors.ErrEncryptionKeySelection
 	candidateSubkey := -1
 	var maxTime time.Time
 	var selectedSubkeySelfSig *packet.Signature
 	for i, subkey := range e.Subkeys {
+		subkeyKeyId := subkey.PublicKey.KeyIdString()
+		subkeyErr := errors.ErrEncryptionKeySelection{
+			PrimaryKeyId:      e.PrimaryKey.KeyIdString(),
+			EncSelectionKeyId: &subkeyKeyId,
+		}
+		// Verify the subkey signature.
 		subkeySelfSig, err := subkey.Verify(now, config) // subkey has to be valid at time now
-		if err == nil &&
-			isValidEncryptionKey(subkeySelfSig, subkey.PublicKey.PubKeyAlgo) &&
-			checkKeyRequirements(subkey.PublicKey, config) == nil &&
-			(maxTime.IsZero() || subkeySelfSig.CreationTime.Unix() >= maxTime.Unix()) {
+		if err != nil {
+			subkeyErr.EncSelectionErr = err
+			latestSelectionError = &subkeyErr
+			continue
+		}
+		// Check the key flags.
+		if !isValidEncryptionKey(subkeySelfSig, subkey.PublicKey.PubKeyAlgo) {
+			continue
+		}
+		// Check if the key fulfils the requirements
+		if err := checkKeyRequirements(subkey.PublicKey, config); err != nil {
+			subkeyErr.EncSelectionErr = err
+			latestSelectionError = &subkeyErr
+			continue
+		}
+		if maxTime.IsZero() || subkeySelfSig.CreationTime.Unix() >= maxTime.Unix() {
 			candidateSubkey = i
 			selectedSubkeySelfSig = subkeySelfSig
 			maxTime = subkeySelfSig.CreationTime
@@ -133,7 +166,7 @@ func (e *Entity) EncryptionKey(now time.Time, config *packet.Config) (Key, bool)
 			PublicKey:            subkey.PublicKey,
 			PrivateKey:           subkey.PrivateKey,
 			SelfSignature:        selectedSubkeySelfSig,
-		}, true
+		}, nil
 	}
 
 	// If we don't have any subkeys for encryption and the primary key
@@ -145,10 +178,17 @@ func (e *Entity) EncryptionKey(now time.Time, config *packet.Config) (Key, bool)
 			PublicKey:            e.PrimaryKey,
 			PrivateKey:           e.PrivateKey,
 			SelfSignature:        primarySelfSignature,
-		}, true
+		}, nil
 	}
 
-	return Key{}, false
+	if latestSelectionError == nil {
+		latestSelectionError = &errors.ErrEncryptionKeySelection{
+			PrimaryKeyId:    e.PrimaryKey.KeyIdString(),
+			EncSelectionErr: goerrors.New("no key with encryption flags found"),
+		}
+	}
+
+	return Key{}, latestSelectionError
 }
 
 // DecryptionKeys returns all keys that are available for decryption, matching the keyID when given

--- a/openpgp/v2/keys_test.go
+++ b/openpgp/v2/keys_test.go
@@ -2022,3 +2022,36 @@ NciH07RTRuMS/aRhRg4OB8PQROmTnZ+iZS0=
 		t.Fatal(err)
 	}
 }
+
+func TestEncryptionKeyError(t *testing.T) {
+	entity, err := NewEntity("Golang Gopher", "Test Key", "no-reply@golang.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = entity.EncryptionKeyWithError(time.Unix(1405544146, 0), nil)
+	if err == nil {
+		t.Fatal("should fail")
+	}
+	if !strings.Contains(err.Error(), "no valid self signature found") {
+		t.Fatal("wrong error")
+	}
+
+	entity.Subkeys[0].Bindings[0].Packet.CreationTime = time.Unix(1405544146, 0)
+	_, err = entity.EncryptionKeyWithError(time.Now(), nil)
+	if err == nil {
+		t.Fatal("should fail")
+	}
+	if !strings.Contains(err.Error(), "no valid binding signature found for subkey") {
+		t.Fatal("wrong error")
+	}
+
+	entity.Subkeys = nil
+	_, err = entity.EncryptionKeyWithError(time.Now(), nil)
+	if err == nil {
+		t.Fatal("should fail")
+	}
+	if !strings.Contains(err.Error(), "no key with encryption flags found") {
+		t.Fatal("wrong error")
+	}
+}

--- a/openpgp/v2/write.go
+++ b/openpgp/v2/write.go
@@ -611,10 +611,8 @@ func encrypt(
 		timeForEncryptionKey = *params.EncryptionTime
 	}
 	for i, recipient := range append(to, toHidden...) {
-		var ok bool
-		encryptKeys[i], ok = recipient.EncryptionKey(timeForEncryptionKey, config)
-		if !ok {
-			return nil, errors.InvalidArgumentError("cannot encrypt a message to key id " + strconv.FormatUint(to[i].PrimaryKey.KeyId, 16) + " because it has no valid encryption keys")
+		if encryptKeys[i], err = recipient.EncryptionKeyWithError(timeForEncryptionKey, config); err != nil {
+			return nil, err
 		}
 
 		primarySelfSignature, _ := recipient.PrimarySelfSignature(timeForEncryptionKey, config)


### PR DESCRIPTION
This PR enhances error messages by providing detailed explanations when key selection for encryption fails in the v2 API.