### PR TITLE
Only check that message signatures are newer than the key

### DIFF
--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -676,7 +676,7 @@ func (e *Entity) LatestValidDirectSignature(date time.Time, config *packet.Confi
 			if sig.Valid == nil {
 				err := e.PrimaryKey.VerifyDirectKeySignature(sig.Packet)
 				if err == nil {
-					err = checkSignatureDetails(e.PrimaryKey, sig.Packet, date, config)
+					err = checkSignatureDetails(sig.Packet, date, config)
 				}
 				valid := err == nil
 				sig.Valid = &valid

--- a/openpgp/v2/subkeys.go
+++ b/openpgp/v2/subkeys.go
@@ -187,7 +187,7 @@ func (s *Subkey) LatestValidBindingSignature(date time.Time, config *packet.Conf
 			if sig.Valid == nil {
 				err := s.Primary.PrimaryKey.VerifyKeySignature(s.PublicKey, sig.Packet)
 				if err == nil {
-					err = checkSignatureDetails(s.Primary.PrimaryKey, sig.Packet, date, config)
+					err = checkSignatureDetails(sig.Packet, date, config)
 				}
 				valid := err == nil
 				sig.Valid = &valid

--- a/openpgp/v2/user.go
+++ b/openpgp/v2/user.go
@@ -121,7 +121,7 @@ func (i *Identity) Revoked(selfCertification *packet.Signature, date time.Time, 
 				// Verify revocation signature (not verified yet).
 				err := i.Primary.PrimaryKey.VerifyUserIdSignature(i.Name, i.Primary.PrimaryKey, revocation.Packet)
 				if err == nil {
-					err = checkSignatureDetails(i.Primary.PrimaryKey, revocation.Packet, date, config)
+					err = checkSignatureDetails(revocation.Packet, date, config)
 				}
 				valid := err == nil
 				revocation.Valid = &valid
@@ -206,7 +206,7 @@ func (i *Identity) LatestValidSelfCertification(date time.Time, config *packet.C
 				// Verify revocation signature (not verified yet).
 				err = i.Primary.PrimaryKey.VerifyUserIdSignature(i.Name, i.Primary.PrimaryKey, sig.Packet)
 				if err == nil {
-					err = checkSignatureDetails(i.Primary.PrimaryKey, sig.Packet, date, config)
+					err = checkSignatureDetails(sig.Packet, date, config)
 				}
 				valid := err == nil
 				sig.Valid = &valid


### PR DESCRIPTION
Don't check that binding signatures are newer than the primary key that created them, as some old keys generated by previous versions of OpenPGP.js fail this check.