### PR TITLE
Tolerate invalid key signatures if one verifies

### DIFF
--- a/openpgp/v2/keys.go
+++ b/openpgp/v2/keys.go
@@ -731,7 +731,7 @@ func (e *Entity) LatestValidDirectSignature(date time.Time, config *packet.Confi
 	if selectedSig == nil {
 		return nil, errors.StructuralError("no valid direct key signature found")
 	}
-	return
+	return selectedSig, nil
 }
 
 // PrimarySelfSignature searches the entity for the self-signature that stores key preferences.

--- a/openpgp/v2/subkeys.go
+++ b/openpgp/v2/subkeys.go
@@ -206,5 +206,5 @@ func (s *Subkey) LatestValidBindingSignature(date time.Time, config *packet.Conf
 	if selectedSig == nil {
 		return nil, errors.StructuralError("no valid binding signature found for subkey")
 	}
-	return
+	return selectedSig, nil
 }

--- a/openpgp/v2/user.go
+++ b/openpgp/v2/user.go
@@ -219,5 +219,5 @@ func (i *Identity) LatestValidSelfCertification(date time.Time, config *packet.C
 	if selectedSig == nil {
 		return nil, errors.StructuralError("no valid certification signature found for identity")
 	}
-	return
+	return selectedSig, nil
 }


### PR DESCRIPTION
Previously, key signature selection could return an error even when a valid signature was available.
This PR fixes the issue by returning the valid signature and ignoring errors from invalid ones if at least one valid signature is found.