### PR TITLE
Add DisableCriticalSubpackets option to remove critical bit from signature subpackets

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -430,6 +430,13 @@ func (c *Config) DecompressedMessageSizeLimit() *int64 {
 	return c.MaxDecompressedMessageSize
 }
 
+func (c *Config) DisabledCriticalSubpackets() bool {
+	if c == nil {
+		return false
+	}
+	return c.DisableCriticalSubpackets
+}
+
 // BoolPointer is a helper function to set a boolean pointer in the Config.
 // e.g., config.CheckPacketSequence = BoolPointer(true)
 func BoolPointer(value bool) *bool {

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -183,6 +183,9 @@ type Config struct {
 	// read from a compressed packet. This serves as an upper limit to prevent
 	// excessively large decompressed messages.
 	MaxDecompressedMessageSize *int64
+
+	// DisableCriticalSubpackets removes the critical flag from all signature subpackets.
+	DisableCriticalSubpackets bool
 }
 
 func (c *Config) Random() io.Reader {

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -185,6 +185,9 @@ type Config struct {
 	MaxDecompressedMessageSize *int64
 
 	// DisableCriticalSubpackets removes the critical flag from all signature subpackets.
+	// This can be needed for messages to be accepted by older clients who do not recognize
+	// some packets and are configured to reject critical packets they do not know (RFC 2440, section 5.2.3.1).
+	// Example: rpm 4.14.3-150400.59.3.1 in OpenSUSE Leap 15.4 not recognizing the key flag subpacket.
 	DisableCriticalSubpackets bool
 }
 

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -1256,29 +1256,30 @@ type outputSubpacket struct {
 
 func (sig *Signature) buildSubpackets(issuer PublicKey, config *Config) (subpackets []outputSubpacket, err error) {
 	creationTime := make([]byte, 4)
+	criticalFlag := !config.DisabledCriticalSubpackets()
 	binary.BigEndian.PutUint32(creationTime, uint32(sig.CreationTime.Unix()))
 	// Signature Creation Time
-	subpackets = append(subpackets, outputSubpacket{true, creationTimeSubpacket, !config.DisableCriticalSubpackets, creationTime})
+	subpackets = append(subpackets, outputSubpacket{true, creationTimeSubpacket, criticalFlag, creationTime})
 	// Signature Expiration Time
 	if sig.SigLifetimeSecs != nil && *sig.SigLifetimeSecs != 0 {
 		sigLifetime := make([]byte, 4)
 		binary.BigEndian.PutUint32(sigLifetime, *sig.SigLifetimeSecs)
-		subpackets = append(subpackets, outputSubpacket{true, signatureExpirationSubpacket, !config.DisableCriticalSubpackets, sigLifetime})
+		subpackets = append(subpackets, outputSubpacket{true, signatureExpirationSubpacket, criticalFlag, sigLifetime})
 	}
 	// Trust Signature
 	if sig.TrustLevel != 0 {
-		subpackets = append(subpackets, outputSubpacket{true, trustSubpacket, !config.DisableCriticalSubpackets, []byte{byte(sig.TrustLevel), byte(sig.TrustAmount)}})
+		subpackets = append(subpackets, outputSubpacket{true, trustSubpacket, criticalFlag, []byte{byte(sig.TrustLevel), byte(sig.TrustAmount)}})
 	}
 	// Regular Expression
 	if sig.TrustRegularExpression != nil {
 		// RFC specifies the string should be null-terminated; add a null byte to the end
-		subpackets = append(subpackets, outputSubpacket{true, regularExpressionSubpacket, !config.DisableCriticalSubpackets, []byte(*sig.TrustRegularExpression + "\000")})
+		subpackets = append(subpackets, outputSubpacket{true, regularExpressionSubpacket, criticalFlag, []byte(*sig.TrustRegularExpression + "\000")})
 	}
 	// Key Expiration Time
 	if sig.KeyLifetimeSecs != nil && *sig.KeyLifetimeSecs != 0 {
 		keyLifetime := make([]byte, 4)
 		binary.BigEndian.PutUint32(keyLifetime, *sig.KeyLifetimeSecs)
-		subpackets = append(subpackets, outputSubpacket{true, keyExpirationSubpacket, !config.DisableCriticalSubpackets, keyLifetime})
+		subpackets = append(subpackets, outputSubpacket{true, keyExpirationSubpacket, criticalFlag, keyLifetime})
 	}
 	// Preferred Symmetric Ciphers for v1 SEIPD
 	if len(sig.PreferredSymmetric) > 0 {
@@ -1357,7 +1358,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey, config *Config) (subpack
 		if sig.FlagGroupKey {
 			flags |= KeyFlagGroupKey
 		}
-		subpackets = append(subpackets, outputSubpacket{true, keyFlagsSubpacket, !config.DisableCriticalSubpackets, []byte{flags}})
+		subpackets = append(subpackets, outputSubpacket{true, keyFlagsSubpacket, criticalFlag, []byte{flags}})
 	}
 	// Signer's User ID
 	if sig.SignerUserId != nil {
@@ -1366,7 +1367,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey, config *Config) (subpack
 	// Reason for Revocation
 	// Revocation reason appears only in revocation signatures and is serialized as per section 5.2.3.31.
 	if sig.RevocationReason != nil {
-		subpackets = append(subpackets, outputSubpacket{true, reasonForRevocationSubpacket, !config.DisableCriticalSubpackets,
+		subpackets = append(subpackets, outputSubpacket{true, reasonForRevocationSubpacket, criticalFlag,
 			append([]uint8{uint8(*sig.RevocationReason)}, []uint8(sig.RevocationReasonText)...)})
 	}
 	// Features
@@ -1388,7 +1389,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey, config *Config) (subpack
 		if err != nil {
 			return
 		}
-		subpackets = append(subpackets, outputSubpacket{true, embeddedSignatureSubpacket, !config.DisableCriticalSubpackets, buf.Bytes()})
+		subpackets = append(subpackets, outputSubpacket{true, embeddedSignatureSubpacket, criticalFlag, buf.Bytes()})
 	}
 	// Issuer Fingerprint
 	if sig.IssuerFingerprint != nil {


### PR DESCRIPTION
## Overview

Adds a new option to `openpgp/packet.Config`, `DisableCriticalSubpackets`, to force the `Sign` method to not add the critical flags to any subpacket.

## Use-case

At Datadog, we have a setup where we have an RSA private key stored in a secrets manager, and we use this library to craft a GPG key from it, in order to sign deb and rpm packages, and to export the public GPG key to let customers import it in their systems.

The exported public key's signature packet contains two critical subpackets ([signature date](https://github.com/ProtonMail/go-crypto/blob/9c711563c820ffa40074cc63a3322ec17b9dbb98/openpgp/packet/signature.go#L1261), and [key flags](https://github.com/ProtonMail/go-crypto/blob/9c711563c820ffa40074cc63a3322ec17b9dbb98/openpgp/packet/signature.go#L1360)), which are always set to true by the [Sign](https://github.com/ProtonMail/go-crypto/blob/9c711563c820ffa40074cc63a3322ec17b9dbb98/openpgp/packet/signature.go#L916) method.

<details>

<summary> gpg --list-packets output</summary>

```
$ gpg --list-packets /mount/public-key.asc
# off=0 ctb=c6 tag=6 hlen=3 plen=397 new-ctb
:public key packet:
   version 4, algo 1, created 1749600000, expires 0
   pkey[0]: [3072 bits]
   pkey[1]: [17 bits]
   keyid: AD7E54B36DF4CD19
# off=400 ctb=cd tag=13 hlen=2 plen=50 new-ctb
:user ID packet: "Datadog Pacakges (Testing) <package@datadoghq.com>"
# off=452 ctb=c2 tag=2 hlen=3 plen=453 new-ctb
:signature packet: algo 1, keyid AD7E54B36DF4CD19
   version 4, created 1751893082, md5len 0, sigclass 0x13
   digest algo 8, begin of digest 97 b5
   critical hashed subpkt 2 len 4 (sig created 2025-07-07)
   hashed subpkt 11 len 1 (pref-sym-algos: 7)
   hashed subpkt 16 len 8 (issuer key ID AD7E54B36DF4CD19)
   hashed subpkt 21 len 1 (pref-hash-algos: 8)
   hashed subpkt 22 len 1 (pref-zip-algos: 0)
   hashed subpkt 25 len 1 (primary user ID)
   critical hashed subpkt 27 len 1 (key flags: 03)
   hashed subpkt 30 len 1 (features: 01)
   hashed subpkt 33 len 21 (issuer fpr v4 BF8CBF16F1F5EA4EE6C44CEBAD7E54B36DF4CD19)
   data: [3072 bits]
```

</details>

These critical subpackets are not accepted by some versions of `rpm`, for instance the version included in OpenSUSE Leap 15.1 to 15.4 (`rpm 4.14.3-150400.59.3.1`). OpenSUSE versions 15.5 and 15.6 (`rpm 4.14.3-150400.59.16.1`) do not have this issue.

For this particular case, with further testing we determined that what trips `rpm` up is the critical subpacket on the key flags subpacket.

<details>

<summary>rpm --import test in OpenSUSE Leap 15.4</summary>

```
$ docker run -v "$PWD:/mount" -it opensuse/leap:15.4 bash
01c10ff07d30:/ # gpg --list-packets /mount/public-key.asc
gpg: keybox '/root/.gnupg/pubring.kbx' created
# off=0 ctb=c6 tag=6 hlen=3 plen=397 new-ctb
:public key packet:
	version 4, algo 1, created 1749600000, expires 0
	pkey[0]: [3072 bits]
	pkey[1]: [17 bits]
	keyid: AD7E54B36DF4CD19
# off=400 ctb=cd tag=13 hlen=2 plen=50 new-ctb
:user ID packet: "Datadog Pacakges (Testing) <package@datadoghq.com>"
# off=452 ctb=c2 tag=2 hlen=3 plen=453 new-ctb
:signature packet: algo 1, keyid AD7E54B36DF4CD19
	version 4, created 1751893082, md5len 0, sigclass 0x13
	digest algo 8, begin of digest 97 b5
	critical hashed subpkt 2 len 4 (sig created 2025-07-07)
	hashed subpkt 11 len 1 (pref-sym-algos: 7)
	hashed subpkt 16 len 8 (issuer key ID AD7E54B36DF4CD19)
	hashed subpkt 21 len 1 (pref-hash-algos: 8)
	hashed subpkt 22 len 1 (pref-zip-algos: 0)
	hashed subpkt 25 len 1 (primary user ID)
	critical hashed subpkt 27 len 1 (key flags: 03)
	hashed subpkt 30 len 1 (features: 01)
	hashed subpkt 33 len 21 (issuer fpr v4 BF8CBF16F1F5EA4EE6C44CEBAD7E54B36DF4CD19)
	data: [3072 bits]
01c10ff07d30:/ # gpg --import /mount/public-key.asc
gpg: /root/.gnupg/trustdb.gpg: trustdb created
gpg: key AD7E54B36DF4CD19: public key "Datadog Pacakges (Testing) <package@datadoghq.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
01c10ff07d30:/ # rpm --import /mount/public-key.asc
error: /mount/public-key.asc: key 1 import failed.
```
</details>

Since we need to continue supporting these OS versions, we'd like to add opt-in configuration to force the `Sign` method to not add the critical subpackets to a signature. In our case, we'd activate this option when adding a user id to the key to ensure the self-signature does not contain critical subpackets.

We currently use a fork to work around this issue, but, if possible, we'd rather continue using your upstream library. Is this something we could add?

## Testing

Tested the exported public key output with the option set to true (none of the subpackets are critical) and false (all expected subpackets are critical).

## Questions

Should this option be prefixed with `Insecure`?