### PR TITLE
Add InsecureGenerateNonCriticalSignatureCreationDate option to generate non-critical signature creation date subpackets

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -185,6 +185,13 @@ type Config struct {
 	// For example, rpm 4.14.3-150400.59.3.1 in OpenSUSE Leap 15.4 does not recognize it.
 	InsecureGenerateNonCriticalKeyFlags bool
 
+	// InsecureGenerateNonCriticalSignatureCreationDate causes the "Signature Creation Date" signature subpacket
+	// to be non-critical in newly generated signatures.
+	// This may be needed for keys to be accepted by older clients who do not recognize
+	// the subpacket.
+	// For example, yum 3.4.3-168 in CentOS 7 and yum 3.4.3-158 Amazon Linux 2 do not recognize it.
+	InsecureGenerateNonCriticalSignatureCreationDate bool
+
 	// MaxDecompressedMessageSize specifies the maximum number of bytes that can be
 	// read from a compressed packet. This serves as an upper limit to prevent
 	// excessively large decompressed messages.
@@ -431,6 +438,13 @@ func (c *Config) GenerateNonCriticalKeyFlags() bool {
 		return false
 	}
 	return c.InsecureGenerateNonCriticalKeyFlags
+}
+
+func (c *Config) GenerateNonCriticalSignatureCreationDate() bool {
+	if c == nil {
+		return false
+	}
+	return c.InsecureGenerateNonCriticalSignatureCreationDate
 }
 
 func (c *Config) DecompressedMessageSizeLimit() *int64 {

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -1258,7 +1258,7 @@ func (sig *Signature) buildSubpackets(issuer PublicKey, config *Config) (subpack
 	creationTime := make([]byte, 4)
 	binary.BigEndian.PutUint32(creationTime, uint32(sig.CreationTime.Unix()))
 	// Signature Creation Time
-	subpackets = append(subpackets, outputSubpacket{true, creationTimeSubpacket, true, creationTime})
+	subpackets = append(subpackets, outputSubpacket{true, creationTimeSubpacket, !config.GenerateNonCriticalSignatureCreationDate(), creationTime})
 	// Signature Expiration Time
 	if sig.SigLifetimeSecs != nil && *sig.SigLifetimeSecs != 0 {
 		sigLifetime := make([]byte, 4)


### PR DESCRIPTION
## Overview

Adds a new option to `openpgp/packet.Config`,`InsecureGenerateNonCriticalSignatureCreationDate`, to force the `Sign` method to not add the critical flag to the signature creation date subpacket.

## Use-case

Hello again from Datadog - this is kind of a follow-up to https://github.com/ProtonMail/go-crypto/pull/291.

After this change, we were able to have `rpm --import` commands work on the affected `rpm` versions contained in openSUSE 15.1 to 15.4.

However, a new problem arose. `yum` in CentOS 7 and AmazonLinux 2 (version `3.4.3-168.el7.centos` and `3.4.3-158.amzn2.0.6`, respectively) does not manage to read a key specified in the `gpgkey` field of a repository definition, if that key only has a critical bit on the signature creation date file (it worked fine when both the key flags and signature creation date had critical bits).

Since the keys we generate must support all these OSes at the same time, we'd like to add another opt-in configuration to force the Sign method to not add the critical bit to the signature creation date subpacket of a signature. In our case, we'd activate this option when adding a user id to the key to ensure the self-signature does not contain the offending critical subpacket.

## Testing

Tested the exported public key output with the option set to true (the signature creation date subpacket is not critical) and false (all expected subpackets are critical).
Added unit test for the option.

