### PR TITLE
Add NoEncryptionSubkey to openpgp/packet/Config

### DIFF
--- a/openpgp/key_generation.go
+++ b/openpgp/key_generation.go
@@ -74,11 +74,13 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 		return nil, err
 	}
 
-	// NOTE: No key expiry here, but we will not return this subkey in EncryptionKey()
-	// if the primary/master key has expired.
-	err = e.addEncryptionSubkey(config, creationTime, 0)
-	if err != nil {
-		return nil, err
+	if !config.NoEncryptionSubkey() {
+		// NOTE: No key expiry here, but we will not return this subkey in EncryptionKey()
+		// if the primary/master key has expired.
+		err = e.addEncryptionSubkey(config, creationTime, 0)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return e, nil

--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -195,6 +195,10 @@ type Config struct {
 	// read from a compressed packet. This serves as an upper limit to prevent
 	// excessively large decompressed messages.
 	MaxDecompressedMessageSize *int64
+
+	// NoEncryptionSubkey configures key generation.  true results in an
+	// OpenPGP key that has no encryption-capable subkey
+	NoEncryptionSubkey bool
 }
 
 func (c *Config) Random() io.Reader {
@@ -451,6 +455,13 @@ func (c *Config) DecompressedMessageSizeLimit() *int64 {
 		return nil
 	}
 	return c.MaxDecompressedMessageSize
+}
+
+func (c *Config) NoEncryptionSubkey() bool {
+	if c == nil {
+		return false
+	}
+	return c.NoEncryptionSubkey
 }
 
 // BoolPointer is a helper function to set a boolean pointer in the Config.

--- a/openpgp/v2/key_generation.go
+++ b/openpgp/v2/key_generation.go
@@ -112,11 +112,13 @@ func newEntity(uid *userIdData, config *packet.Config) (*Entity, error) {
 		}
 	}
 
-	// NOTE: No key expiry here, but we will not return this subkey in EncryptionKey()
-	// if the primary/master key has expired.
-	err = e.addEncryptionSubkey(config, creationTime, 0)
-	if err != nil {
-		return nil, err
+	if !config.NoEncryptionSubkey() {
+		// NOTE: No key expiry here, but we will not return this subkey in EncryptionKey()
+		// if the primary/master key has expired.
+		err = e.addEncryptionSubkey(config, creationTime, 0)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return e, nil


### PR DESCRIPTION
This is a step toward being able to support

    gosop generate-key --signing-only

See https://github.com/ProtonMail/gosop/issues/43